### PR TITLE
8247432: Update IANA Language Subtag Registry to Version 202X-XX-XX

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2020-04-01
+File-Date: 2020-06-10
 %%
 Type: language
 Subtag: aa
@@ -11260,6 +11260,11 @@ Description: Fyer
 Added: 2009-07-29
 %%
 Type: language
+Subtag: fif
+Description: Faifi
+Added: 2020-06-08
+%%
+Type: language
 Subtag: fil
 Description: Filipino
 Description: Pilipino
@@ -12529,15 +12534,15 @@ Added: 2009-07-29
 Scope: collection
 %%
 Type: language
-Subtag: gmu
-Description: Gumalu
-Added: 2009-07-29
-%%
-Type: language
 Subtag: gmr
 Description: Mirning
 Description: Mirniny
 Added: 2020-03-28
+%%
+Type: language
+Subtag: gmu
+Description: Gumalu
+Added: 2009-07-29
 %%
 Type: language
 Subtag: gmv
@@ -34310,6 +34315,8 @@ Type: language
 Subtag: thw
 Description: Thudam
 Added: 2009-07-29
+Deprecated: 2020-06-08
+Preferred-Value: ola
 %%
 Type: language
 Subtag: thx
@@ -45121,6 +45128,11 @@ Description: Tirhuta
 Added: 2011-08-16
 %%
 Type: script
+Subtag: Toto
+Description: Toto
+Added: 2020-05-12
+%%
+Type: script
 Subtag: Ugar
 Description: Ugaritic
 Added: 2005-10-16
@@ -47467,6 +47479,14 @@ Comments: The subtag represents Branislau Taraskievic's Belarusian
   orthography as published in "Bielaruski klasycny pravapis" by Juras
   Buslakou, Vincuk Viacorka, Zmicier Sanko, and Zmicier Sauka (Vilnia-
   Miensk 2005).
+%%
+Type: variant
+Subtag: tongyong
+Description: Tongyong Pinyin romanization
+Added: 2020-06-08
+Prefix: zh-Latn
+Comments: Former official transcription standard for Mandarin Chinese in
+  Taiwan.
 %%
 Type: variant
 Subtag: uccor

--- a/test/jdk/java/util/Locale/Bug8040211.java
+++ b/test/jdk/java/util/Locale/Bug8040211.java
@@ -45,7 +45,7 @@ public class Bug8040211 {
     private static final String ACCEPT_LANGUAGE =
         "Accept-Language: aam, adp, aog, aue, bcg, bpp, cey, cnp, cqu, csp, dif, dmw, ema,"
         + " en-gb-oed, gti, kdz, koj, kru, kwq, kxe, kzk, lii, lmm, lsn, lsv, lvi, mtm,"
-        + " ngv, nns, oyb, phr, pnd, pub, scv, snz, suj, szy, taj, tjj, tjp, tvx,"
+        + " ngv, nns, ola, oyb, phr, pnd, pub, scv, snz, suj, szy, taj, tjj, tjp, tvx,"
         + " uss, uth, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";
     private static final List<LanguageRange> EXPECTED_RANGE_LIST = List.of(
             new LanguageRange("aam", 1.0),
@@ -105,6 +105,8 @@ public class Bug8040211 {
             new LanguageRange("nnx", 1.0),
             new LanguageRange("nns", 1.0),
             new LanguageRange("nbr", 1.0),
+            new LanguageRange("ola", 1.0),
+            new LanguageRange("thw", 1.0),
             new LanguageRange("oyb", 1.0),
             new LanguageRange("thx", 1.0),
             new LanguageRange("skk", 1.0),


### PR DESCRIPTION
dummy.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8247432](https://bugs.openjdk.java.net/browse/JDK-8247432): Update IANA Language Subtag Registry to Version 202X-XX-XX


### Download
`$ git fetch https://git.openjdk.java.net/playground pull/3/head:pull/3`
`$ git checkout pull/3`
