### PR TITLE
8218021: jarsigner keep POSIX permissions

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipEntry.java
+++ b/src/java.base/share/classes/java/util/zip/ZipEntry.java
@@ -57,7 +57,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
     int flag = 0;       // general purpose flag
     byte[] extra;       // optional extra field data for entry
     String comment;     // optional comment string for entry
-
+    int posixPerms = -1;// posix permissions
     /**
      * Compression method for uncompressed entries.
      */
@@ -131,6 +131,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
         flag = e.flag;
         extra = e.extra;
         comment = e.comment;
+        posixPerms = e.posixPerms;
     }
 
     /**

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -657,6 +657,11 @@ public class ZipFile implements ZipConstants, Closeable {
         e.size = CENLEN(cen, pos);
         e.csize = CENSIZ(cen, pos);
         e.method = CENHOW(cen, pos);
+        if (CENVEM_FA(cen, pos) == FILE_ATTRIBUTES_UNIX) {
+            // 12 bits for setuid, setgid, sticky + perms
+            e.posixPerms = CENATX_PERMS(cen, pos) & 0xFFF;
+        }
+
         if (elen != 0) {
             int start = pos + CENHDR + nlen;
             e.setExtra0(Arrays.copyOfRange(cen, start, start + elen), true, false);
@@ -1092,6 +1097,16 @@ public class ZipFile implements ZipConstants, Closeable {
                 public Stream<String> entryNameStream(ZipFile zip) {
                     return zip.entryNameStream();
                 }
+                // only set posix perms value via ZipEntry contructor for now
+                @Override
+                public int getPosixPerms(ZipEntry ze) {
+                    return ze.posixPerms;
+                }
+                @Override
+                public void setPosixPerms(ZipEntry ze, int perms) {
+                    ze.posixPerms = perms;
+                }
+
              }
         );
         isWindows = VM.getSavedProperty("os.name").contains("Windows");

--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -506,6 +506,15 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
         }
     }
 
+    /**
+     * Adds information about compatibility of file attribute information
+     * to a version value.
+     */
+    private int versionMadeBy(ZipEntry e, int version) {
+        return (e.posixPerms < 0) ? version :
+                VERSION_MADE_BY_BASE_UNIX | (version & 0xff);
+    }
+
     /*
      * Write central directory (CEN) header for specified entry.
      * REMIND: add support for file attributes
@@ -537,10 +546,10 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
         }
         writeInt(CENSIG);           // CEN header signature
         if (hasZip64) {
-            writeShort(45);         // ver 4.5 for zip64
+            writeShort(versionMadeBy(e,45));         // ver 4.5 for zip64
             writeShort(45);
         } else {
-            writeShort(version);    // version made by
+            writeShort(versionMadeBy(e, version));    // version made by
             writeShort(version);    // version needed to extract
         }
         writeShort(flag);           // general purpose bit flag
@@ -597,7 +606,8 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
         }
         writeShort(0);              // starting disk number
         writeShort(0);              // internal file attributes (unused)
-        writeInt(0);                // external file attributes (unused)
+        // external file attributes, used for storing posix permissions
+        writeInt(e.posixPerms > 0 ? e.posixPerms << 16 : 0);
         writeInt(offset);           // relative offset of local header
         writeBytes(nameBytes, 0, nameBytes.length);
 

--- a/src/java.base/share/classes/java/util/zip/ZipUtils.java
+++ b/src/java.base/share/classes/java/util/zip/ZipUtils.java
@@ -215,6 +215,17 @@ class ZipUtils {
         return LG(b, 0);
     }
 
+    /*
+     * File attribute compatibility types of CEN field "version made by"
+     */
+    static final int FILE_ATTRIBUTES_UNIX = 3; // Unix
+
+    /*
+     * Base values for CEN field "version made by"
+     */
+    static final int VERSION_MADE_BY_BASE_UNIX = FILE_ATTRIBUTES_UNIX << 8; // Unix
+
+
     // local file (LOC) header fields
     static final long LOCSIG(byte[] b) { return LG(b, 0); } // signature
     static final int  LOCVER(byte[] b) { return SH(b, 4); } // version needed to extract
@@ -250,6 +261,7 @@ class ZipUtils {
     // central directory header (CEN) fields
     static final long CENSIG(byte[] b, int pos) { return LG(b, pos + 0); }
     static final int  CENVEM(byte[] b, int pos) { return SH(b, pos + 4); }
+    static final int  CENVEM_FA(byte[] b, int pos) { return CH(b, pos + 5); } // file attribute compatibility
     static final int  CENVER(byte[] b, int pos) { return SH(b, pos + 6); }
     static final int  CENFLG(byte[] b, int pos) { return SH(b, pos + 8); }
     static final int  CENHOW(byte[] b, int pos) { return SH(b, pos + 10);}
@@ -263,6 +275,7 @@ class ZipUtils {
     static final int  CENDSK(byte[] b, int pos) { return SH(b, pos + 34);}
     static final int  CENATT(byte[] b, int pos) { return SH(b, pos + 36);}
     static final long CENATX(byte[] b, int pos) { return LG(b, pos + 38);}
+    static final int  CENATX_PERMS(byte[] b, int pos) { return SH(b, pos + 40);} // posix permission data
     static final long CENOFF(byte[] b, int pos) { return LG(b, pos + 42);}
 
     // The END header is followed by a variable length comment of size < 64k.

--- a/src/java.base/share/classes/jdk/internal/access/JavaUtilZipFileAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaUtilZipFileAccess.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 public interface JavaUtilZipFileAccess {
@@ -40,5 +41,7 @@ public interface JavaUtilZipFileAccess {
     public Enumeration<JarEntry> entries(ZipFile zip);
     public Stream<JarEntry> stream(ZipFile zip);
     public Stream<String> entryNameStream(ZipFile zip);
+    public void setPosixPerms(ZipEntry ze, int posixPerms);
+    public int getPosixPerms(ZipEntry ze);
 }
 

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -149,6 +149,7 @@ module java.base {
         java.management,
         java.naming,
         java.rmi,
+        jdk.jartool,
         jdk.jlink,
         jdk.net,
         jdk.incubator.foreign;

--- a/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/DistributionPointFetcher.java
@@ -248,7 +248,7 @@ public class DistributionPointFetcher {
             debug.println("Trying to fetch CRL from DP " + uri);
         }
 
-        Event.report("event.crl.check", uri.toString());
+        Event.report(Event.ReporterCategory.CRLCHECK,"event.crl.check", uri.toString());
         CertStore ucs = null;
         try {
             ucs = URICertStore.getInstance(new URICertStoreParameters(uri));

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -234,7 +234,7 @@ public final class OCSP {
                 debug.println("connecting to OCSP service at: " + url);
             }
 
-            Event.report("event.ocsp.check", url.toString());
+            Event.report(Event.ReporterCategory.CRLCHECK,"event.ocsp.check", url.toString());
             HttpURLConnection con = (HttpURLConnection)url.openConnection();
             con.setConnectTimeout(CONNECT_TIMEOUT);
             con.setReadTimeout(CONNECT_TIMEOUT);

--- a/src/java.base/share/classes/sun/security/util/Event.java
+++ b/src/java.base/share/classes/sun/security/util/Event.java
@@ -35,21 +35,27 @@ package sun.security.util;
 public final class Event {
     private Event() {}
 
+    public enum ReporterCategory {
+        CRLCHECK(),
+        POSIXPERMS();
+
+        private Reporter reporter;
+    }
+
     public interface Reporter {
         public void handle(String type, Object... args);
     }
 
-    private static Reporter reporter;
-    public static void setReportListener(Reporter re) {
-        reporter = re;
+    public static void setReportListener(ReporterCategory cat, Reporter re) {
+        cat.reporter = re;
     }
 
-    public static void clearReportListener() {
-        reporter = null;
+    public static void clearReportListener(ReporterCategory cat) {
+        cat.reporter = null;
     }
 
-    public static void report(String type, Object... args) {
-        Reporter currentReporter = reporter;
+    public static void report(ReporterCategory cat, String type, Object... args) {
+        Reporter currentReporter = cat.reporter;
 
         if (currentReporter != null) {
             currentReporter.handle(type, args);

--- a/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
+++ b/src/jdk.jartool/share/classes/jdk/security/jarsigner/JarSigner.java
@@ -27,8 +27,11 @@ package jdk.security.jarsigner;
 
 import com.sun.jarsigner.ContentSigner;
 import com.sun.jarsigner.ContentSignerParameters;
+import jdk.internal.access.JavaUtilZipFileAccess;
+import jdk.internal.access.SharedSecrets;
 import sun.security.tools.PathList;
 import sun.security.tools.jarsigner.TimestampedSigner;
+import sun.security.util.Event;
 import sun.security.util.ManifestDigester;
 import sun.security.util.SignatureFileVerifier;
 import sun.security.x509.AlgorithmId;
@@ -81,6 +84,8 @@ import java.util.zip.ZipOutputStream;
  * @since 9
  */
 public final class JarSigner {
+
+    static final JavaUtilZipFileAccess JUZFA = SharedSecrets.getJavaUtilZipFileAccess();
 
     /**
      * A mutable builder class that can create an immutable {@code JarSigner}
@@ -500,6 +505,7 @@ public final class JarSigner {
     private final boolean externalSF; // leave the .SF out of the PKCS7 block
     private final String altSignerPath;
     private final String altSigner;
+    private boolean posixPermsDetected;
 
     private JarSigner(JarSigner.Builder builder) {
 
@@ -943,6 +949,12 @@ public final class JarSigner {
         ze2.setTime(ze.getTime());
         ze2.setComment(ze.getComment());
         ze2.setExtra(ze.getExtra());
+        int perms = JUZFA.getPosixPerms(ze);
+        if (!posixPermsDetected && perms != -1) {
+            posixPermsDetected = true;
+            Event.report(Event.ReporterCategory.POSIXPERMS, "true");
+        }
+        JUZFA.setPosixPerms(ze2, perms);
         if (ze.getMethod() == ZipEntry.STORED) {
             ze2.setSize(ze.getSize());
             ze2.setCrc(ze.getCrc());

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -50,6 +50,8 @@ import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.TrustAnchor;
 import java.util.Map.Entry;
 
+import jdk.internal.access.JavaUtilZipFileAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.security.jarsigner.JarSigner;
 import jdk.security.jarsigner.JarSignerException;
 import sun.security.pkcs.PKCS7;
@@ -108,12 +110,16 @@ public class Main {
     private static final Set<CryptoPrimitive> SIG_PRIMITIVE_SET = Collections
             .unmodifiableSet(EnumSet.of(CryptoPrimitive.SIGNATURE));
 
+    private static boolean permsDetected;
+
     static final String VERSION = "1.0";
 
     static final int IN_KEYSTORE = 0x01;        // signer is in keystore
     static final int NOT_ALIAS = 0x04;          // alias list is NOT empty and
     // signer is not in alias list
     static final int SIGNED_BY_ALIAS = 0x08;    // signer is in alias list
+
+    static final JavaUtilZipFileAccess JUZFA = SharedSecrets.getJavaUtilZipFileAccess();
 
     // Attention:
     // This is the entry that get launched by the security tool jarsigner.
@@ -294,7 +300,7 @@ public class Main {
                 Arrays.fill(storepass, ' ');
                 storepass = null;
             }
-            Event.clearReportListener();
+            Event.clearReportListener(Event.ReporterCategory.CRLCHECK);
         }
 
         if (strict) {
@@ -776,6 +782,9 @@ public class Main {
                     JarEntry je = e.nextElement();
                     String name = je.getName();
 
+                    if (!permsDetected && JUZFA.getPosixPerms(je) != -1) {
+                        permsDetected = true;
+                    }
                     hasSignature = hasSignature
                             || SignatureFileVerifier.isBlockOrSF(name);
 
@@ -1054,7 +1063,7 @@ public class Main {
                 notYetValidCert || chainNotValidated || hasExpiredCert ||
                 hasUnsignedEntry || signerSelfSigned || (legacyAlg != 0) ||
                 (disabledAlg != 0) || aliasNotInStore || notSignedByAlias ||
-                tsaChainNotValidated ||
+                tsaChainNotValidated || permsDetected ||
                 (hasExpiredTsaCert && !signerNotExpired)) {
 
             if (strict) {
@@ -1133,6 +1142,10 @@ public class Main {
                 errors.add(isSigning
                         ? rb.getString("The.signer.s.certificate.is.self.signed.")
                         : rb.getString("This.jar.contains.entries.whose.signer.certificate.is.self.signed."));
+            }
+
+            if (permsDetected) {
+                warnings.add(rb.getString("posix.attributes.detected"));
             }
 
             if (isSigning) {
@@ -1771,6 +1784,8 @@ public class Main {
         String failedMessage = null;
 
         try {
+            Event.setReportListener(Event.ReporterCategory.POSIXPERMS,
+                    (t, o) -> permsDetected = true);
             builder.build().sign(zipFile, fos);
         } catch (JarSignerException e) {
             failedCause = e.getCause();
@@ -1805,6 +1820,7 @@ public class Main {
                 fos.close();
             }
 
+            Event.clearReportListener(Event.ReporterCategory.POSIXPERMS);
         }
 
         if (failedCause != null) {
@@ -2064,7 +2080,8 @@ public class Main {
                     if (revocationCheck) {
                         Security.setProperty("ocsp.enable", "true");
                         System.setProperty("com.sun.security.enableCRLDP", "true");
-                        Event.setReportListener((t, o) -> System.out.println(String.format(rb.getString(t), o)));
+                        Event.setReportListener(Event.ReporterCategory.CRLCHECK,
+                                (t, o) -> System.out.println(String.format(rb.getString(t), o)));
                     }
                     pkixParameters.setRevocationEnabled(revocationCheck);
                 } catch (InvalidAlgorithmParameterException ex) {

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Resources.java
@@ -170,6 +170,7 @@ public class Resources extends java.util.ListResourceBundle {
         {"key.bit.weak", "%d-bit key (weak)"},
         {"key.bit.disabled", "%d-bit key (disabled)"},
         {"unknown.size", "unknown size"},
+        {"posix.attributes.detected", "POSIX file permission attributes detected. Note that these attributes are unsigned and not protected by the signature."},
 
         {"jarsigner.", "jarsigner: "},
         {"signature.filename.must.consist.of.the.following.characters.A.Z.0.9.or.",

--- a/test/jdk/sun/security/tools/jarsigner/PosixPermissionsTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/PosixPermissionsTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8218021
+ * @summary Have jarsigner preserve posix permission attributes
+ * @modules jdk.jartool/sun.security.tools.jarsigner
+ *          java.base/sun.security.tools.keytool
+ * @library /test/lib
+ * @run main/othervm PosixPermissionsTest
+ */
+
+import java.net.URI;
+import java.nio.file.*;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.*;
+
+import jdk.test.lib.SecurityTools;
+
+public class PosixPermissionsTest {
+
+    private static List<String> perms = List.of(
+            "---------",
+            "r--------",
+            "-w-------",
+            "--x------",
+            "rwx------",
+            "---r-----",
+            "----w----",
+            "-----x---",
+            "---rwx---",
+            "------r--",
+            "-------w-",
+            "--------x",
+            "------rwx",
+            "r--r-----",
+            "r--r--r--",
+            "rw-rw----",
+            "rwxrwx---",
+            "rw-rw-r--",
+            "r-xr-x---",
+            "r-xr-xr-x",
+            "rwxrwxrwx");
+
+    private final static String ZIPFILENAME = "8218021-test.zip";
+    private final static String JARFILENAME = "8218021-test.jar";
+    private final static URI JARURI = URI.create("jar:" + Path.of(JARFILENAME).toUri());
+    private final static URI ZIPURI = URI.create("jar:" + Path.of(ZIPFILENAME).toUri());
+    private static Path file;
+    private static int count;
+    private static Set<PosixFilePermission> permsSet;
+    private static String expectedJarPerms;
+    private static final String POSIXWARNING = "POSIX file permission attributes detected. " +
+        "Note that these attributes are unsigned and not protected by the signature.";
+
+    public static void main(String[] args) throws Exception {
+        if (!FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            System.out.println("No posix support. Skipping");
+            return;
+        }
+
+        createFiles();
+        // check permissions before signing
+        verifyFilePermissions(ZIPURI, true);
+        verifyFilePermissions(JARURI, false);
+
+        SecurityTools.keytool(
+                "-genkey",
+                "-keyalg", "RSA",
+                "-dname", "CN=Coffey, OU=JPG, O=Oracle, L=Santa Clara, ST=California, C=US",
+                "-alias", "examplekey",
+                "-storepass", "password",
+                "-keypass", "password",
+                "-keystore", "examplekeystore",
+                "-validity", "365")
+                .shouldHaveExitValue(0);
+
+        SecurityTools.jarsigner(
+                "-keystore", "examplekeystore",
+                "-verbose", ZIPFILENAME,
+                "-storepass", "password",
+                "-keypass", "password",
+                "examplekey")
+                .shouldHaveExitValue(0)
+                .shouldContain(POSIXWARNING);
+
+        // zip file now signed. Recheck file permissions
+        verifyFilePermissions(ZIPURI, true);
+
+        // sign jar file - no posix warning message expected
+        SecurityTools.jarsigner("-keystore", "examplekeystore",
+                "-verbose", JARFILENAME,
+                "-storepass", "password",
+                "-keypass", "password",
+                "examplekey")
+                .shouldHaveExitValue(0)
+                .shouldNotContain(POSIXWARNING);
+
+        // default attributes expected
+        verifyFilePermissions(JARURI, false);
+
+        SecurityTools.jarsigner("-keystore", "examplekeystore",
+                "-storepass", "password",
+                "-keypass", "password",
+                "-verbose",
+                "-verify", ZIPFILENAME)
+                .shouldHaveExitValue(0)
+                .shouldContain(POSIXWARNING);
+
+        // no warning expected for regular jar file
+        SecurityTools.jarsigner("-keystore", "examplekeystore",
+                "-storepass", "password",
+                "-keypass", "password",
+                "-verbose",
+                "-verify", JARFILENAME)
+                .shouldHaveExitValue(0)
+                .shouldNotContain(POSIXWARNING);
+    }
+
+    private static void createFiles() throws Exception {
+
+        String fileList = " ";
+        Map<String, String> env = new HashMap<>();
+        env.put("create", "true");
+        env.put("enablePosixFileAttributes", "true");
+
+        try (FileSystem zipfs = FileSystems.newFileSystem(ZIPURI, env)) {
+            for (String s : perms) {
+                file = Path.of("test_" + count++);
+                fileList += file + " ";
+                permsSet = PosixFilePermissions.fromString(s);
+                Files.createFile(file);
+
+                Files.copy(file,
+                        zipfs.getPath(file.toString()),
+                        StandardCopyOption.COPY_ATTRIBUTES);
+                Files.setPosixFilePermissions(zipfs.getPath(file.toString()), permsSet);
+            }
+        }
+
+        // create jar file for testing also
+        SecurityTools.jar("cf " + JARFILENAME + fileList);
+        try (FileSystem jarfs = FileSystems.newFileSystem(JARURI, env)) {
+            expectedJarPerms = PosixFilePermissions.toString(
+                    Files.getPosixFilePermissions(jarfs.getPath("test_1")));
+        }
+    }
+
+    private static void verifyFilePermissions(URI u, boolean containAttributes) throws Exception {
+        count = 0;
+        for (String s : perms) {
+            file = Path.of("test_" + count++);
+            checkEntryAttributes(u, file, s, containAttributes);
+        }
+    }
+
+    private static void checkEntryAttributes(URI uri, Path file,
+                                             String expectedPerms, boolean containAttributes) throws Exception {
+        try (FileSystem zipfs = FileSystems.newFileSystem(uri, Map.of("enablePosixFileAttributes", "true"))) {
+            Path p = zipfs.getPath(file.getFileName().toString());
+            Set<PosixFilePermission> permsSet = Files.getPosixFilePermissions(p);
+            String actualPerms = PosixFilePermissions.toString(permsSet);
+            if (containAttributes) {
+                if (!expectedPerms.equals(actualPerms)) {
+                    throw new RuntimeException("Unexpected permissions for: " + file + ". Received: " + actualPerms);
+                }
+            } else {
+                if (!actualPerms.equals(expectedJarPerms)) {
+                    throw new RuntimeException("Expected default permissions for " + file);
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/sun/security/util/Resources/Usages.java
+++ b/test/jdk/sun/security/util/Resources/Usages.java
@@ -75,7 +75,7 @@ public class Usages {
             "(?m)rb[ \\n]*\\.getString[ \\n]*\\([ \\n]*\"(.*?)\"\\)");
 
     static Pattern EVENT_OCSP_CRL = Pattern.compile(
-            "Event\\.report\\(\"(.*?)\",");
+            "Event\\.report\\(.*,\"(.*?)\",");
 
     // Command and Option enums in keytool
     static Pattern KT_ENUM = Pattern.compile("\\n +[A-Z]+\\(.*\"(.*)\"");


### PR DESCRIPTION
Let jarsigner knows about POSIX permissions
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8218021](https://bugs.openjdk.java.net/browse/JDK-8218021): Have jarsigner preserve posix permission attributes ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * dholmes - **Reviewer** ⚠️ Added manually
 * jlahoda - **Reviewer** ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/playground pull/8/head:pull/8`
`$ git checkout pull/8`
