### PR TITLE
8243592: Subject$SecureSet::addAll should not call contains(null)

### DIFF
--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -203,21 +203,20 @@ public final class Subject implements java.io.Serializable {
      *          Sets.
      */
     public Subject(boolean readOnly, Set<? extends Principal> principals,
-                   Set<?> pubCredentials, Set<?> privCredentials)
-    {
-        LinkedList<Principal> princList
+                   Set<?> pubCredentials, Set<?> privCredentials) {
+        LinkedList<Principal> principalList
                 = collectionNullClean(principals);
         LinkedList<Object> pubCredsList
                 = collectionNullClean(pubCredentials);
         LinkedList<Object> privCredsList
                 = collectionNullClean(privCredentials);
 
-        this.principals = Collections.synchronizedSet(new SecureSet<>
-                                (this, PRINCIPAL_SET, princList));
-        this.pubCredentials = Collections.synchronizedSet(new SecureSet<>
-                                (this, PUB_CREDENTIAL_SET, pubCredsList));
-        this.privCredentials = Collections.synchronizedSet(new SecureSet<>
-                                (this, PRIV_CREDENTIAL_SET, privCredsList));
+        this.principals = Collections.synchronizedSet(
+                new SecureSet<>(this, PRINCIPAL_SET, principalList));
+        this.pubCredentials = Collections.synchronizedSet(
+                new SecureSet<>(this, PUB_CREDENTIAL_SET, pubCredsList));
+        this.privCredentials = Collections.synchronizedSet(
+                new SecureSet<>(this, PRIV_CREDENTIAL_SET, privCredsList));
         this.readOnly = readOnly;
     }
 
@@ -978,9 +977,9 @@ public final class Subject implements java.io.Serializable {
 
         // Rewrap the principals into a SecureSet
         try {
-            LinkedList<Principal> princList = collectionNullClean(inputPrincs);
+            LinkedList<Principal> principalList = collectionNullClean(inputPrincs);
             principals = Collections.synchronizedSet(new SecureSet<>
-                                (this, PRINCIPAL_SET, princList));
+                                (this, PRINCIPAL_SET, principalList));
         } catch (NullPointerException npe) {
             // Sometimes people deserialize the principals set only.
             // Subject is not accessible, so just don't fail.

--- a/test/jdk/javax/security/auth/Subject/UnreliableContains.java
+++ b/test/jdk/javax/security/auth/Subject/UnreliableContains.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8243592
+ * @summary Subject$SecureSet::addAll should not call contains(null)
+ */
+
+import javax.security.auth.Subject;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+
+public class UnreliableContains {
+
+    public static void main(String[] args) {
+        MySet<Principal> set = new MySet<>();
+        set.add(null);
+        Subject s = null;
+        try {
+            s = new Subject(false, set, Collections.emptySet(),
+                    Collections.emptySet());
+        } catch (NullPointerException e) {
+            // The correct exit
+            return;
+        }
+        // Suppose NPE was not caught. At least null was not added?
+        for (Principal p : s.getPrincipals()) {
+            Objects.requireNonNull(p);
+        }
+        // Still must fail. We don't want this Subject created
+        throw new RuntimeException("Fail");
+    }
+
+    // This is a Map that implements contains(null) differently
+    static class MySet<E> extends HashSet<E> {
+        @Override
+        public boolean contains(Object o) {
+            if (o == null) {
+                return false;
+            } else {
+                return super.contains(o);
+            }
+        }
+    }
+}


### PR DESCRIPTION
A rewrite of fix.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8243592](https://bugs.openjdk.java.net/browse/JDK-8243592): Subject$SecureSet::contains(null) is suboptimal ⚠️ Title mismatch between PR and JBS.


### Download
`$ git fetch https://git.openjdk.java.net/playground pull/9/head:pull/9`
`$ git checkout pull/9`
