### PR TITLE
8246797: A convenient method to read OPTIONAL element

### DIFF
--- a/src/java.base/share/classes/java/security/cert/PolicyQualifierInfo.java
+++ b/src/java.base/share/classes/java/security/cert/PolicyQualifierInfo.java
@@ -27,8 +27,10 @@ package java.security.cert;
 
 import java.io.IOException;
 
+import sun.security.util.DerOutputStream;
 import sun.security.util.HexDumpEncoder;
 import sun.security.util.DerValue;
+import sun.security.util.ObjectIdentifier;
 
 /**
  * An immutable policy qualifier represented by the ASN.1 PolicyQualifierInfo
@@ -90,6 +92,28 @@ public class PolicyQualifierInfo {
     private String pqiString;
 
     /**
+     * Creates from material.
+     * @param mId id
+     * @param mData data
+     */
+    public PolicyQualifierInfo(String mId, byte[] mData) {
+        this.mId = mId;
+        this.mData = mData;
+    }
+
+    private void encodeThis() throws IOException {
+        if (mEncoded != null) {
+            return;
+        }
+        DerOutputStream out = new DerOutputStream();
+        DerOutputStream ins = new DerOutputStream();
+        ins.putOID(ObjectIdentifier.of(mId));
+        ins.write(mData);
+        out.write(DerValue.tag_Sequence, ins);
+        mEncoded = out.toByteArray();
+    }
+
+    /**
      * Creates an instance of {@code PolicyQualifierInfo} from the
      * encoded bytes. The encoded byte array is copied on construction.
      *
@@ -134,7 +158,8 @@ public class PolicyQualifierInfo {
      * Note that a copy is returned, so the data is cloned each time
      * this method is called.
      */
-    public final byte[] getEncoded() {
+    public final byte[] getEncoded() throws IOException {
+        encodeThis();
         return mEncoded.clone();
     }
 

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
@@ -266,6 +266,14 @@ public class PKCS7 {
         }
     }
 
+
+    //    SignedData ::= SEQUENCE {
+    //        version CMSVersion,
+    //        digestAlgorithms DigestAlgorithmIdentifiers,
+    //        encapContentInfo EncapsulatedContentInfo,
+    //        certificates [0] IMPLICIT CertificateSet OPTIONAL,
+    //        crls [1] IMPLICIT RevocationInfoChoices OPTIONAL,
+    //        signerInfos SignerInfos }
     private void parseSignedData(DerValue val)
         throws ParsingException, IOException {
 
@@ -305,7 +313,7 @@ public class PKCS7 {
          * check if certificates (implicit tag) are provided
          * (certificates are OPTIONAL)
          */
-        if ((byte)(dis.peekByte()) == (byte)0xA0) {
+        if (dis.seeOptionalContextSpecific(0)) {
             DerValue[] certVals = dis.getSet(2, true);
 
             len = certVals.length;
@@ -350,7 +358,7 @@ public class PKCS7 {
         }
 
         // check if crls (implicit tag) are provided (crls are OPTIONAL)
-        if ((byte)(dis.peekByte()) == (byte)0xA1) {
+        if (dis.seeOptionalContextSpecific(1)) {
             DerValue[] crlVals = dis.getSet(1, true);
 
             len = crlVals.length;

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS8Key.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS8Key.java
@@ -108,27 +108,16 @@ public class PKCS8Key implements PrivateKey {
             algid = AlgorithmId.parse (val.data.getDerValue ());
             key = val.data.getOctetString ();
 
-            DerValue next;
-            if (val.data.available() == 0) {
-                return;
+            if (val.data.seeOptionalContextSpecific(0)) {
+                val.data.skipDerValue();
             }
-            next = val.data.getDerValue();
-            if (next.isContextSpecific((byte)0)) {
-                if (val.data.available() == 0) {
-                    return;
-                }
-                next = val.data.getDerValue();
-            }
-
-            if (next.isContextSpecific((byte)1)) {
+            if (val.data.seeOptionalContextSpecific(1)) {
                 if (version == V1) {
                     throw new InvalidKeyException("publicKey seen in v1");
                 }
-                if (val.data.available() == 0) {
-                    return;
-                }
+                val.data.skipDerValue();
             }
-            throw new InvalidKeyException("Extra bytes");
+            val.data.atEnd();
         } catch (IOException e) {
             throw new InvalidKeyException("IOException : " + e.getMessage());
         }

--- a/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
+++ b/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
@@ -129,6 +129,15 @@ public class SignerInfo implements DerEncoder {
     /**
      * Parses a PKCS#7 signer info.
      *
+     * SignerInfo ::= SEQUENCE {
+     *         version CMSVersion,
+     *         sid SignerIdentifier,
+     *         digestAlgorithm DigestAlgorithmIdentifier,
+     *         signedAttrs [0] IMPLICIT SignedAttributes OPTIONAL,
+     *         signatureAlgorithm SignatureAlgorithmIdentifier,
+     *         signature SignatureValue,
+     *         unsignedAttrs [1] IMPLICIT UnsignedAttributes OPTIONAL }
+     *
      * <p>This constructor is used only for backwards compatibility with
      * PKCS#7 blocks that were generated using JDK1.1.x.
      *
@@ -162,7 +171,7 @@ public class SignerInfo implements DerEncoder {
         } else {
             // check if set of auth attributes (implicit tag) is provided
             // (auth attributes are OPTIONAL)
-            if ((byte)(derin.peekByte()) == (byte)0xA0) {
+            if (derin.seeOptionalContextSpecific(0)) {
                 authenticatedAttributes = new PKCS9Attributes(derin);
             }
         }
@@ -184,8 +193,7 @@ public class SignerInfo implements DerEncoder {
         } else {
             // check if set of unauth attributes (implicit tag) is provided
             // (unauth attributes are OPTIONAL)
-            if (derin.available() != 0
-                && (byte)(derin.peekByte()) == (byte)0xA1) {
+            if (derin.seeOptionalContextSpecific(1)) {
                 unauthenticatedAttributes =
                     new PKCS9Attributes(derin, true);// ignore unsupported attrs
             }

--- a/src/java.base/share/classes/sun/security/timestamp/TSResponse.java
+++ b/src/java.base/share/classes/sun/security/timestamp/TSResponse.java
@@ -40,7 +40,7 @@ import sun.security.util.DerValue;
  *
  *     TimeStampResp ::= SEQUENCE {
  *         status            PKIStatusInfo,
- *         timeStampToken    TimeStampToken OPTIONAL ]
+ *         timeStampToken    TimeStampToken OPTIONAL }
  *
  *     PKIStatusInfo ::= SEQUENCE {
  *         status        PKIStatus,
@@ -332,17 +332,14 @@ public class TSResponse {
             debug.println("timestamp response: status=" + this.status);
         }
         // Parse statusString, if present
-        if (statusInfo.data.available() > 0) {
-            byte tag = (byte)statusInfo.data.peekByte();
-            if (tag == DerValue.tag_SequenceOf) {
-                DerValue[] strings = statusInfo.data.getSequence(1);
-                statusString = new String[strings.length];
-                for (int i = 0; i < strings.length; i++) {
-                    statusString[i] = strings[i].getUTF8String();
-                    if (debug != null) {
-                        debug.println("timestamp response: statusString=" +
-                                      statusString[i]);
-                    }
+        if (statusInfo.data.seeOptional(DerValue.tag_SequenceOf)) {
+            DerValue[] strings = statusInfo.data.getSequence(1);
+            statusString = new String[strings.length];
+            for (int i = 0; i < strings.length; i++) {
+                statusString[i] = strings[i].getUTF8String();
+                if (debug != null) {
+                    debug.println("timestamp response: statusString=" +
+                            statusString[i]);
                 }
             }
         }

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1557,7 +1557,11 @@ public final class Main {
                 badCerts[i] = new X509CRLEntryImpl(new BigInteger(ids.get(i)), firstDate);
             }
         }
-        X509CRLImpl crl = new X509CRLImpl(owner, firstDate, lastDate, badCerts);
+        CRLExtensions crlExts = new CRLExtensions();
+        AuthorityKeyIdentifierExtension ext = new AuthorityKeyIdentifierExtension(
+                new KeyIdentifier(signerCert.getPublicKey()), null, null);
+        crlExts.set(ext.getId(), ext);
+        X509CRLImpl crl = new X509CRLImpl(owner, firstDate, lastDate, badCerts, crlExts);
         crl.sign(privateKey, sigAlgName);
         if (rfc) {
             out.println("-----BEGIN X509 CRL-----");

--- a/src/java.base/share/classes/sun/security/util/DerInputBuffer.java
+++ b/src/java.base/share/classes/sun/security/util/DerInputBuffer.java
@@ -61,13 +61,12 @@ class DerInputBuffer extends ByteArrayInputStream implements Cloneable {
     }
 
     DerInputBuffer dup() {
-        try {
-            DerInputBuffer retval = (DerInputBuffer)clone();
-            retval.mark(Integer.MAX_VALUE);
-            return retval;
-        } catch (CloneNotSupportedException e) {
-            throw new IllegalArgumentException(e.toString());
-        }
+        DerInputBuffer retval = new DerInputBuffer(this.buf);
+        retval.pos = this.pos;
+        retval.count = this.count;
+        retval.allowBER = this.allowBER;
+        retval.mark = this.pos;
+        return retval;
     }
 
     byte[] toByteArray() {

--- a/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -155,41 +155,25 @@ implements CertAttrSet<String> {
                                   "AuthorityKeyIdentifierExtension.");
         }
 
-        // Note that all the fields in AuthorityKeyIdentifier are defined as
-        // being OPTIONAL, i.e., there could be an empty SEQUENCE, resulting
-        // in val.data being null.
-        while ((val.data != null) && (val.data.available() != 0)) {
-            DerValue opt = val.data.getDerValue();
-
-            // NB. this is always encoded with the IMPLICIT tag
-            // The checks only make sense if we assume implicit tagging,
-            // with explicit tagging the form is always constructed.
-            if (opt.isContextSpecific(TAG_ID) && !opt.isConstructed()) {
-                if (id != null)
-                    throw new IOException("Duplicate KeyIdentifier in " +
-                                          "AuthorityKeyIdentifier.");
-                opt.resetTag(DerValue.tag_OctetString);
-                id = new KeyIdentifier(opt);
-
-            } else if (opt.isContextSpecific(TAG_NAMES) &&
-                       opt.isConstructed()) {
-                if (names != null)
-                    throw new IOException("Duplicate GeneralNames in " +
-                                          "AuthorityKeyIdentifier.");
-                opt.resetTag(DerValue.tag_Sequence);
-                names = new GeneralNames(opt);
-
-            } else if (opt.isContextSpecific(TAG_SERIAL_NUM) &&
-                       !opt.isConstructed()) {
-                if (serialNum != null)
-                    throw new IOException("Duplicate SerialNumber in " +
-                                          "AuthorityKeyIdentifier.");
-                opt.resetTag(DerValue.tag_Integer);
-                serialNum = new SerialNumber(opt);
-            } else
-                throw new IOException("Invalid encoding of " +
-                                      "AuthorityKeyIdentifierExtension.");
+        var v = val.data.getOptionalImplicitContextSpecific(
+                TAG_ID, DerValue.tag_OctetString);
+        if (v.isPresent()) {
+            id = new KeyIdentifier(v.get());
         }
+
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_NAMES, DerValue.tag_Sequence);
+        if (v.isPresent()) {
+            names = new GeneralNames(v.get());
+        }
+
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_SERIAL_NUM, DerValue.tag_Integer);
+        if (v.isPresent()) {
+            serialNum = new SerialNumber(v.get().getBigInteger());
+        }
+
+        val.data.atEnd();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CRLExtensions.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLExtensions.java
@@ -41,23 +41,7 @@ import sun.security.util.*;
 
 /**
  * This class defines the CRL Extensions.
- * It is used for both CRL Extensions and CRL Entry Extensions,
- * which are defined are follows:
- * <pre>
- * TBSCertList  ::=  SEQUENCE  {
- *    version              Version OPTIONAL,   -- if present, must be v2
- *    signature            AlgorithmIdentifier,
- *    issuer               Name,
- *    thisUpdate           Time,
- *    nextUpdate           Time  OPTIONAL,
- *    revokedCertificates  SEQUENCE OF SEQUENCE  {
- *        userCertificate         CertificateSerialNumber,
- *        revocationDate          Time,
- *        crlEntryExtensions      Extensions OPTIONAL  -- if present, must be v2
- *    }  OPTIONAL,
- *    crlExtensions        [0] EXPLICIT Extensions OPTIONAL  -- if present, must be v2
- * }
- * </pre>
+ * It is used for both CRL Extensions and CRL Entry Extensions.
  *
  * @author Hemma Prafullchandra
  */
@@ -87,15 +71,6 @@ public class CRLExtensions {
     private void init(DerInputStream derStrm) throws CRLException {
         try {
             DerInputStream str = derStrm;
-
-            byte nextByte = (byte)derStrm.peekByte();
-            // check for context specific byte 0; skip it
-            if (((nextByte & 0x0c0) == 0x080) &&
-                ((nextByte & 0x01f) == 0x000)) {
-                DerValue val = str.getDerValue();
-                str = val.data;
-            }
-
             DerValue[] exts = str.getSequence(5);
             for (int i = 0; i < exts.length; i++) {
                 Extension ext = new Extension(exts[i]);

--- a/src/java.base/share/classes/sun/security/x509/CertificateVersion.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateVersion.java
@@ -71,17 +71,6 @@ public class CertificateVersion implements CertAttrSet<String> {
         return(version);
     }
 
-    // Construct the class from the passed DerValue
-    private void construct(DerValue derVal) throws IOException {
-        if (derVal.isConstructed() && derVal.isContextSpecific()) {
-            derVal = derVal.data.getDerValue();
-            version = derVal.getInteger();
-            if (derVal.data.available() != 0) {
-                throw new IOException("X.509 version, bad format");
-            }
-        }
-    }
-
     /**
      * The default constructor for this class,
      *  sets the version to 0 (i.e. X.509 version 1).
@@ -105,44 +94,6 @@ public class CertificateVersion implements CertAttrSet<String> {
             throw new IOException("X.509 Certificate version " +
                                    version + " not supported.\n");
         }
-    }
-
-    /**
-     * Create the object, decoding the values from the passed DER stream.
-     *
-     * @param in the DerInputStream to read the CertificateVersion from.
-     * @exception IOException on decoding errors.
-     */
-    public CertificateVersion(DerInputStream in) throws IOException {
-        version = V1;
-        DerValue derVal = in.getDerValue();
-
-        construct(derVal);
-    }
-
-    /**
-     * Create the object, decoding the values from the passed stream.
-     *
-     * @param in the InputStream to read the CertificateVersion from.
-     * @exception IOException on decoding errors.
-     */
-    public CertificateVersion(InputStream in) throws IOException {
-        version = V1;
-        DerValue derVal = new DerValue(in);
-
-        construct(derVal);
-    }
-
-    /**
-     * Create the object, decoding the values from the passed DerValue.
-     *
-     * @param val the Der encoded value.
-     * @exception IOException on decoding errors.
-     */
-    public CertificateVersion(DerValue val) throws IOException {
-        version = V1;
-
-        construct(val);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/DistributionPoint.java
+++ b/src/java.base/share/classes/sun/security/x509/DistributionPoint.java
@@ -192,51 +192,36 @@ public class DistributionPoint {
             throw new IOException("Invalid encoding of DistributionPoint.");
         }
 
-        // Note that all the fields in DistributionPoint are defined as
-        // being OPTIONAL, i.e., there could be an empty SEQUENCE, resulting
-        // in val.data being null.
-        while ((val.data != null) && (val.data.available() != 0)) {
-            DerValue opt = val.data.getDerValue();
-
-            if (opt.isContextSpecific(TAG_DIST_PT) && opt.isConstructed()) {
-                if ((fullName != null) || (relativeName != null)) {
-                    throw new IOException("Duplicate DistributionPointName in "
-                                          + "DistributionPoint.");
-                }
-                DerValue distPnt = opt.data.getDerValue();
-                if (distPnt.isContextSpecific(TAG_FULL_NAME)
-                        && distPnt.isConstructed()) {
-                    distPnt.resetTag(DerValue.tag_Sequence);
-                    fullName = new GeneralNames(distPnt);
-                } else if (distPnt.isContextSpecific(TAG_REL_NAME)
-                        && distPnt.isConstructed()) {
-                    distPnt.resetTag(DerValue.tag_Set);
-                    relativeName = new RDN(distPnt);
-                } else {
-                    throw new IOException("Invalid DistributionPointName in "
-                                          + "DistributionPoint");
-                }
-            } else if (opt.isContextSpecific(TAG_REASONS)
-                                                && !opt.isConstructed()) {
-                if (reasonFlags != null) {
-                    throw new IOException("Duplicate Reasons in " +
-                                          "DistributionPoint.");
-                }
-                opt.resetTag(DerValue.tag_BitString);
-                reasonFlags = (opt.getUnalignedBitString()).toBooleanArray();
-            } else if (opt.isContextSpecific(TAG_ISSUER)
-                                                && opt.isConstructed()) {
-                if (crlIssuer != null) {
-                    throw new IOException("Duplicate CRLIssuer in " +
-                                          "DistributionPoint.");
-                }
-                opt.resetTag(DerValue.tag_Sequence);
-                crlIssuer = new GeneralNames(opt);
+        var v = val.data.getOptionalExplicitContextSpecific(TAG_DIST_PT);
+        if (v.isPresent()) {
+            DerValue distPnt = v.get();
+            if (distPnt.isContextSpecific(TAG_FULL_NAME)
+                    && distPnt.isConstructed()) {
+                distPnt.resetTag(DerValue.tag_Sequence);
+                fullName = new GeneralNames(distPnt);
+            } else if (distPnt.isContextSpecific(TAG_REL_NAME)
+                    && distPnt.isConstructed()) {
+                distPnt.resetTag(DerValue.tag_Set);
+                relativeName = new RDN(distPnt);
             } else {
-                throw new IOException("Invalid encoding of " +
-                                      "DistributionPoint.");
+                throw new IOException("Invalid DistributionPointName in "
+                        + "DistributionPoint");
             }
         }
+
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_REASONS, DerValue.tag_BitString);
+        if (v.isPresent()) {
+            reasonFlags = (v.get().getUnalignedBitString()).toBooleanArray();
+        }
+
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_ISSUER, DerValue.tag_Sequence);
+        if (v.isPresent()) {
+            crlIssuer = new GeneralNames(v.get());
+        }
+
+        val.data.atEnd();
         if ((crlIssuer == null) && (fullName == null) && (relativeName == null)) {
             throw new IOException("One of fullName, relativeName, "
                 + " and crlIssuer has to be set");

--- a/src/java.base/share/classes/sun/security/x509/EDIPartyName.java
+++ b/src/java.base/share/classes/sun/security/x509/EDIPartyName.java
@@ -80,32 +80,21 @@ public class EDIPartyName implements GeneralNameInterface {
      * @exception IOException on error.
      */
     public EDIPartyName(DerValue derValue) throws IOException {
-        DerInputStream in = new DerInputStream(derValue.toByteArray());
-        DerValue[] seq = in.getSequence(2);
-
-        int len = seq.length;
-        if (len < 1 || len > 2)
-            throw new IOException("Invalid encoding of EDIPartyName");
-
-        for (int i = 0; i < len; i++) {
-            DerValue opt = seq[i];
-            if (opt.isContextSpecific(TAG_ASSIGNER) &&
-                !opt.isConstructed()) {
-                if (assigner != null)
-                    throw new IOException("Duplicate nameAssigner found in"
-                                          + " EDIPartyName");
-                opt = opt.data.getDerValue();
-                assigner = opt.getAsString();
-            }
-            if (opt.isContextSpecific(TAG_PARTYNAME) &&
-                !opt.isConstructed()) {
-                if (party != null)
-                    throw new IOException("Duplicate partyName found in"
-                                          + " EDIPartyName");
-                opt = opt.data.getDerValue();
-                party = opt.getAsString();
-            }
+        if (derValue.tag != DerValue.tag_Sequence) {
+            throw new IOException("Invalid encoding of EDIPartyName.");
         }
+        var v = derValue.data.getOptionalExplicitContextSpecific(TAG_ASSIGNER);
+        if (v.isPresent()) {
+            assigner = v.get().getAsString();
+        }
+        // party is in fact not OPTIONAL
+        v = derValue.data.getOptionalExplicitContextSpecific(TAG_PARTYNAME);
+        if (v.isPresent()) {
+            party = v.get().getAsString();
+        } else {
+            throw new IOException("party must be present");
+        }
+        derValue.data.atEnd();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/GeneralSubtree.java
+++ b/src/java.base/share/classes/sun/security/x509/GeneralSubtree.java
@@ -77,22 +77,21 @@ public class GeneralSubtree {
         }
         name = new GeneralName(val.data.getDerValue(), true);
 
-        // NB. this is always encoded with the IMPLICIT tag
-        // The checks only make sense if we assume implicit tagging,
-        // with explicit tagging the form is always constructed.
-        while (val.data.available() != 0) {
-            DerValue opt = val.data.getDerValue();
-
-            if (opt.isContextSpecific(TAG_MIN) && !opt.isConstructed()) {
-                opt.resetTag(DerValue.tag_Integer);
-                minimum = opt.getInteger();
-
-            } else if (opt.isContextSpecific(TAG_MAX) && !opt.isConstructed()) {
-                opt.resetTag(DerValue.tag_Integer);
-                maximum = opt.getInteger();
-            } else
-                throw new IOException("Invalid encoding of GeneralSubtree.");
+        var v = val.data.getOptionalImplicitContextSpecific(
+                TAG_MIN, DerValue.tag_Integer);
+        if (v.isPresent()) {
+            minimum = v.get().getInteger();
+            if (minimum == 0) {
+                throw new IOException("default minimum encoded");
+            }
         }
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_MAX, DerValue.tag_Integer);
+        if (v.isPresent()) {
+            maximum = v.get().getInteger();
+        }
+
+        val.data.atEnd();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
@@ -181,43 +181,55 @@ public class IssuingDistributionPointExtension extends Extension
                                   "IssuingDistributionPointExtension.");
         }
 
-        // All the elements in issuingDistributionPoint are optional
-        if ((val.data == null) || (val.data.available() == 0)) {
-            return;
+        var v = val.data.getOptionalExplicitContextSpecific(
+                TAG_DISTRIBUTION_POINT);
+        if (v.isPresent()) {
+            distributionPoint = new DistributionPointName(v.get());
         }
 
-        DerInputStream in = val.data;
-        while (in != null && in.available() != 0) {
-            DerValue opt = in.getDerValue();
-
-            if (opt.isContextSpecific(TAG_DISTRIBUTION_POINT) &&
-                opt.isConstructed()) {
-                distributionPoint =
-                    new DistributionPointName(opt.data.getDerValue());
-            } else if (opt.isContextSpecific(TAG_ONLY_USER_CERTS) &&
-                       !opt.isConstructed()) {
-                opt.resetTag(DerValue.tag_Boolean);
-                hasOnlyUserCerts = opt.getBoolean();
-            } else if (opt.isContextSpecific(TAG_ONLY_CA_CERTS) &&
-                  !opt.isConstructed()) {
-                opt.resetTag(DerValue.tag_Boolean);
-                hasOnlyCACerts = opt.getBoolean();
-            } else if (opt.isContextSpecific(TAG_ONLY_SOME_REASONS) &&
-                       !opt.isConstructed()) {
-                revocationReasons = new ReasonFlags(opt); // expects tag implicit
-            } else if (opt.isContextSpecific(TAG_INDIRECT_CRL) &&
-                       !opt.isConstructed()) {
-                opt.resetTag(DerValue.tag_Boolean);
-                isIndirectCRL = opt.getBoolean();
-            } else if (opt.isContextSpecific(TAG_ONLY_ATTRIBUTE_CERTS) &&
-                       !opt.isConstructed()) {
-                opt.resetTag(DerValue.tag_Boolean);
-                hasOnlyAttributeCerts = opt.getBoolean();
-            } else {
-                throw new IOException
-                    ("Invalid encoding of IssuingDistributionPoint");
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_ONLY_USER_CERTS, DerValue.tag_Boolean);
+        if (v.isPresent()) {
+            hasOnlyUserCerts = v.get().getBoolean();
+            if (!hasOnlyUserCerts) {
+                throw new IOException("default hasOnlyUserCerts encoded");
             }
         }
+
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_ONLY_CA_CERTS, DerValue.tag_Boolean);
+        if (v.isPresent()) {
+            hasOnlyCACerts = v.get().getBoolean();
+            if (!hasOnlyCACerts) {
+                throw new IOException("default hasOnlyCACerts encoded");
+            }
+        }
+
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_ONLY_SOME_REASONS, DerValue.tag_BitString);
+        if (v.isPresent()) {
+            revocationReasons = new ReasonFlags(v.get());
+        }
+
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_INDIRECT_CRL, DerValue.tag_Boolean);
+        if (v.isPresent()) {
+            isIndirectCRL = v.get().getBoolean();
+            if (!isIndirectCRL) {
+                throw new IOException("default isIndirectCRL encoded");
+            }
+        }
+
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_ONLY_ATTRIBUTE_CERTS, DerValue.tag_Boolean);
+        if (v.isPresent()) {
+            hasOnlyAttributeCerts = v.get().getBoolean();
+            if (!hasOnlyAttributeCerts) {
+                throw new IOException("default hasOnlyAttributeCerts encoded");
+            }
+        }
+
+        val.data.atEnd();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
@@ -177,37 +177,20 @@ implements CertAttrSet<String>, Cloneable {
                                   " NameConstraintsExtension.");
         }
 
-        // NB. this is always encoded with the IMPLICIT tag
-        // The checks only make sense if we assume implicit tagging,
-        // with explicit tagging the form is always constructed.
-        // Note that all the fields in NameConstraints are defined as
-        // being OPTIONAL, i.e., there could be an empty SEQUENCE, resulting
-        // in val.data being null.
-        if (val.data == null)
-            return;
-        while (val.data.available() != 0) {
-            DerValue opt = val.data.getDerValue();
-
-            if (opt.isContextSpecific(TAG_PERMITTED) && opt.isConstructed()) {
-                if (permitted != null) {
-                    throw new IOException("Duplicate permitted " +
-                         "GeneralSubtrees in NameConstraintsExtension.");
-                }
-                opt.resetTag(DerValue.tag_Sequence);
-                permitted = new GeneralSubtrees(opt);
-
-            } else if (opt.isContextSpecific(TAG_EXCLUDED) &&
-                       opt.isConstructed()) {
-                if (excluded != null) {
-                    throw new IOException("Duplicate excluded " +
-                             "GeneralSubtrees in NameConstraintsExtension.");
-                }
-                opt.resetTag(DerValue.tag_Sequence);
-                excluded = new GeneralSubtrees(opt);
-            } else
-                throw new IOException("Invalid encoding of " +
-                                      "NameConstraintsExtension.");
+        var v = val.data.getOptionalImplicitContextSpecific(
+                TAG_PERMITTED, DerValue.tag_Sequence);
+        if (v.isPresent()) {
+            permitted = new GeneralSubtrees(v.get());
         }
+
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_EXCLUDED, DerValue.tag_Sequence);
+        if (v.isPresent()) {
+            excluded = new GeneralSubtrees(v.get());
+        }
+
+        val.data.atEnd();
+
         minMaxValid = false;
     }
 

--- a/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
@@ -148,27 +148,19 @@ implements CertAttrSet<String> {
         if (val.tag != DerValue.tag_Sequence) {
             throw new IOException("Sequence tag missing for PolicyConstraint.");
         }
-        DerInputStream in = val.data;
-        while (in != null && in.available() != 0) {
-            DerValue next = in.getDerValue();
-
-            if (next.isContextSpecific(TAG_REQUIRE) && !next.isConstructed()) {
-                if (this.require != -1)
-                    throw new IOException("Duplicate requireExplicitPolicy" +
-                          "found in the PolicyConstraintsExtension");
-                next.resetTag(DerValue.tag_Integer);
-                this.require = next.getInteger();
-
-            } else if (next.isContextSpecific(TAG_INHIBIT) &&
-                       !next.isConstructed()) {
-                if (this.inhibit != -1)
-                    throw new IOException("Duplicate inhibitPolicyMapping" +
-                          "found in the PolicyConstraintsExtension");
-                next.resetTag(DerValue.tag_Integer);
-                this.inhibit = next.getInteger();
-            } else
-                throw new IOException("Invalid encoding of PolicyConstraint");
+        var v = val.data.getOptionalImplicitContextSpecific(
+                TAG_REQUIRE, DerValue.tag_Integer);
+        if (v.isPresent()) {
+            this.require = v.get().getInteger();
         }
+
+        v = val.data.getOptionalImplicitContextSpecific(
+                TAG_INHIBIT, DerValue.tag_Integer);
+        if (v.isPresent()) {
+            this.inhibit = v.get().getInteger();
+        }
+
+        val.data.atEnd();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/PolicyInformation.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyInformation.java
@@ -104,16 +104,16 @@ public class PolicyInformation {
             throw new IOException("Invalid encoding of PolicyInformation");
         }
         policyIdentifier = new CertificatePolicyId(val.data.getDerValue());
-        if (val.data.available() != 0) {
+        if (val.data.seeOptional(DerValue.tag_Sequence)) {
             policyQualifiers = new LinkedHashSet<PolicyQualifierInfo>();
             DerValue opt = val.data.getDerValue();
-            if (opt.tag != DerValue.tag_Sequence)
-                throw new IOException("Invalid encoding of PolicyInformation");
-            if (opt.data.available() == 0)
+            if (opt.data.available() == 0) {
                 throw new IOException("No data available in policyQualifiers");
-            while (opt.data.available() != 0)
+            }
+            while (opt.data.available() != 0) {
                 policyQualifiers.add(new PolicyQualifierInfo
                         (opt.data.getDerValue().toByteArray()));
+            }
         } else {
             policyQualifiers = Collections.emptySet();
         }

--- a/src/java.base/share/classes/sun/security/x509/X509CRLEntryImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLEntryImpl.java
@@ -467,19 +467,13 @@ public class X509CRLEntryImpl extends X509CRLEntry
         this.serialNumber = new SerialNumber(val);
 
         // revocationDate
-        int nextByte = derVal.data.peekByte();
-        if ((byte)nextByte == DerValue.tag_UtcTime) {
-            this.revocationDate = derVal.data.getUTCTime();
-        } else if ((byte)nextByte == DerValue.tag_GeneralizedTime) {
-            this.revocationDate = derVal.data.getGeneralizedTime();
-        } else
-            throw new CRLException("Invalid encoding for revocation date");
+        this.revocationDate = derVal.data.getTime();
 
         if (derVal.data.available() == 0)
             return;  // no extensions
 
         // crlEntryExtensions
-        this.extensions = new CRLExtensions(derVal.toDerInputStream());
+        this.extensions = new CRLExtensions(derVal.data);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -1126,8 +1126,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
 
         // version (optional if v1)
         version = 0;   // by default, version = v1 == 0
-        nextByte = (byte)derStrm.peekByte();
-        if (nextByte == DerValue.tag_Integer) {
+        if (derStrm.seeOptional(DerValue.tag_Integer)) {
             version = derStrm.getInteger();
             if (version != 1)  // i.e. v2
                 throw new CRLException("Invalid version");
@@ -1151,34 +1150,14 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
         // thisUpdate
         // check if UTCTime encoded or GeneralizedTime
 
-        nextByte = (byte)derStrm.peekByte();
-        if (nextByte == DerValue.tag_UtcTime) {
-            thisUpdate = derStrm.getUTCTime();
-        } else if (nextByte == DerValue.tag_GeneralizedTime) {
-            thisUpdate = derStrm.getGeneralizedTime();
-        } else {
-            throw new CRLException("Invalid encoding for thisUpdate"
-                                   + " (tag=" + nextByte + ")");
+        thisUpdate = derStrm.getTime();
+
+        if (derStrm.seeOptional(t ->
+                t == DerValue.tag_UtcTime || t == DerValue.tag_GeneralizedTime)) {
+            nextUpdate = derStrm.getTime();
         }
 
-        if (derStrm.available() == 0)
-           return;     // done parsing no more optional fields present
-
-        // nextUpdate (optional)
-        nextByte = (byte)derStrm.peekByte();
-        if (nextByte == DerValue.tag_UtcTime) {
-            nextUpdate = derStrm.getUTCTime();
-        } else if (nextByte == DerValue.tag_GeneralizedTime) {
-            nextUpdate = derStrm.getGeneralizedTime();
-        } // else it is not present
-
-        if (derStrm.available() == 0)
-            return;     // done parsing no more optional fields present
-
-        // revokedCertificates (optional)
-        nextByte = (byte)derStrm.peekByte();
-        if ((nextByte == DerValue.tag_SequenceOf)
-            && (! ((nextByte & 0x0c0) == 0x080))) {
+        if (derStrm.seeOptional(DerValue.tag_SequenceOf)) {
             DerValue[] badCerts = derStrm.getSequence(4);
 
             X500Principal crlIssuer = getIssuerX500Principal();
@@ -1194,13 +1173,8 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
             }
         }
 
-        if (derStrm.available() == 0)
-            return;     // done parsing no extensions
-
-        // crlExtensions (optional)
-        tmp = derStrm.getDerValue();
-        if (tmp.isConstructed() && tmp.isContextSpecific((byte)0)) {
-            extensions = new CRLExtensions(tmp.data);
+        if (derStrm.seeOptionalContextSpecific(0)) {
+            extensions = new CRLExtensions(derStrm.getDerValue().data);
         }
         readOnly = true;
     }
@@ -1220,12 +1194,10 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
 
             DerValue tmp;
             // skip version number if present
-            byte nextByte = (byte)tbsIn.peekByte();
-            if (nextByte == DerValue.tag_Integer) {
-                tmp = tbsIn.getDerValue();
+            if (tbsIn.seeOptional(DerValue.tag_Integer)) {
+                tbsIn.skipDerValue();
             }
-
-            tmp = tbsIn.getDerValue();  // skip signature
+            tbsIn.skipDerValue();
             tmp = tbsIn.getDerValue();  // issuer
             byte[] principalBytes = tmp.toByteArray();
             return new X500Principal(principalBytes);

--- a/test/jdk/sun/security/pkcs/pkcs8/PKCS8Test.java
+++ b/test/jdk/sun/security/pkcs/pkcs8/PKCS8Test.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8048357 8244565
+ * @bug 8048357 8244565 8246797
  * @summary PKCS8 Standards Conformance Tests
  * @library /test/lib
  * @modules java.base/sun.security.pkcs
@@ -85,15 +85,20 @@ public class PKCS8Test {
                 Utils.toHexString(encodedOutput));
 
         // Test additional fields
-        enlarge(0, "8000");    // attributes
-        enlarge(1, "810100");  // public key for v2
-        enlarge(1, "8000", "810100");  // both
+        String attr = "8000";
+        String pubK = "810100";
+        enlarge(0, attr);    // attributes
+        enlarge(1, pubK);  // public key for v2
+        enlarge(1, attr, pubK);  // both
 
         Assert.assertThrows(() -> enlarge(2));  // bad ver
-        Assert.assertThrows(() -> enlarge(0, "8000", "8000")); // no dup
-        Assert.assertThrows(() -> enlarge(0, "810100")); // no public in v1
-        Assert.assertThrows(() -> enlarge(1, "810100", "8000")); // bad order
-        Assert.assertThrows(() -> enlarge(1, "820100")); // bad tag
+        Assert.assertThrows(() -> enlarge(0, "4000")); // no application
+        Assert.assertThrows(() -> enlarge(0, "c000")); // no private
+        Assert.assertThrows(() -> enlarge(0, attr, attr)); // no dup
+        Assert.assertThrows(() -> enlarge(0, attr, "8200")); // no extra
+        Assert.assertThrows(() -> enlarge(0, pubK)); // no public in v1
+        Assert.assertThrows(() -> enlarge(1, pubK, attr)); // bad order
+        Assert.assertThrows(() -> enlarge(1, "8200")); // bad tag
     }
 
     /**

--- a/test/jdk/sun/security/util/DerValue/Indefinite.java
+++ b/test/jdk/sun/security/util/DerValue/Indefinite.java
@@ -26,9 +26,13 @@
  * @bug 6731685
  * @summary CertificateFactory.generateCertificates throws IOException on PKCS7 cert chain
  * @modules java.base/sun.security.util
+ * @library /test/lib
  */
 
 import java.io.*;
+import java.util.Arrays;
+
+import jdk.test.lib.Asserts;
 import sun.security.util.*;
 
 public class Indefinite {
@@ -36,10 +40,30 @@ public class Indefinite {
     public static void main(String[] args) throws Exception {
         byte[] input = {
             // An OCTET-STRING in 2 parts
-            4, (byte)0x80, 4, 2, 'a', 'b', 4, 2, 'c', 'd', 0, 0,
-            // Garbage follows, may be falsely recognized as EOC
-            0, 0, 0, 0
+            0x24, (byte)0x80, 4, 2, 'a', 'b', 4, 2, 'c', 'd', 0, 0,
         };
-        new DerValue(new ByteArrayInputStream(input));
+
+        // Add some garbage, may be falsely recognized as EOC
+        new DerValue(new ByteArrayInputStream(
+                Arrays.copyOf(input, input.length + 4)));
+
+        // Make a SEQUENCE of input and (bool) true.
+        byte[] comp = new byte[input.length + 5];
+        comp[0] = DerValue.tag_Sequence;
+        comp[1] = (byte)(input.length + 3);
+        System.arraycopy(input, 0, comp, 2, input.length);
+        comp[2 + input.length] = comp[3 + input.length] = comp[4 + input.length] = 1;
+
+        // Read it
+        DerValue d = new DerValue(comp);
+        Asserts.assertEQ(new String(d.data.getDerValue().getOctetString()), "abcd");
+        Asserts.assertTrue(d.data.getBoolean());
+        d.data.atEnd();
+
+        // Or skip it
+        d = new DerValue(comp);
+        d.data.skipDerValue();
+        Asserts.assertTrue(d.data.getBoolean());
+        d.data.atEnd();
     }
 }


### PR DESCRIPTION
Add some DerInputStream methods to simplify OPTIONAL element reading. Update
the x509 classes to make use of the new methods.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8246797](https://bugs.openjdk.java.net/browse/JDK-8246797): A convenient method to read OPTIONAL element


### Download
`$ git fetch https://git.openjdk.java.net/playground pull/11/head:pull/11`
`$ git checkout pull/11`
