### PR TITLE
8252141: Rename G1YoungRemSetSamplingThread to better reflect its purpose

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1476,7 +1476,7 @@ public:
 
 G1CollectedHeap::G1CollectedHeap() :
   CollectedHeap(),
-  _young_gen_sampling_thread(NULL),
+  _service_thread(NULL),
   _workers(NULL),
   _card_table(NULL),
   _soft_ref_policy(),
@@ -1612,9 +1612,9 @@ jint G1CollectedHeap::initialize_concurrent_refinement() {
   return ecode;
 }
 
-jint G1CollectedHeap::initialize_young_gen_sampling_thread() {
-  _young_gen_sampling_thread = new G1ServiceThread();
-  if (_young_gen_sampling_thread->osthread() == NULL) {
+jint G1CollectedHeap::initialize_service_thread() {
+  _service_thread = new G1ServiceThread();
+  if (_service_thread->osthread() == NULL) {
     vm_shutdown_during_initialization("Could not create G1ServiceThread");
     return JNI_ENOMEM;
   }
@@ -1790,7 +1790,7 @@ jint G1CollectedHeap::initialize() {
     return ecode;
   }
 
-  ecode = initialize_young_gen_sampling_thread();
+  ecode = initialize_service_thread();
   if (ecode != JNI_OK) {
     return ecode;
   }
@@ -1836,7 +1836,7 @@ void G1CollectedHeap::stop() {
   // do not continue to execute and access resources (e.g. logging)
   // that are destroyed during shutdown.
   _cr->stop();
-  _young_gen_sampling_thread->stop();
+  _service_thread->stop();
   _cm_thread->stop();
   if (G1StringDedup::is_enabled()) {
     G1StringDedup::stop();
@@ -2575,7 +2575,7 @@ void G1CollectedHeap::gc_threads_do(ThreadClosure* tc) const {
   tc->do_thread(_cm_thread);
   _cm->threads_do(tc);
   _cr->threads_do(tc);
-  tc->do_thread(_young_gen_sampling_thread);
+  tc->do_thread(_service_thread);
   if (G1StringDedup::is_enabled()) {
     G1StringDedup::threads_do(tc);
   }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -63,7 +63,7 @@
 #include "gc/g1/g1ThreadLocalData.hpp"
 #include "gc/g1/g1Trace.hpp"
 #include "gc/g1/g1YCTypes.hpp"
-#include "gc/g1/g1YoungRemSetSamplingThread.hpp"
+#include "gc/g1/g1ServiceThread.hpp"
 #include "gc/g1/g1VMOperations.hpp"
 #include "gc/g1/heapRegion.inline.hpp"
 #include "gc/g1/heapRegionRemSet.hpp"
@@ -1613,9 +1613,9 @@ jint G1CollectedHeap::initialize_concurrent_refinement() {
 }
 
 jint G1CollectedHeap::initialize_young_gen_sampling_thread() {
-  _young_gen_sampling_thread = new G1YoungRemSetSamplingThread();
+  _young_gen_sampling_thread = new G1ServiceThread();
   if (_young_gen_sampling_thread->osthread() == NULL) {
-    vm_shutdown_during_initialization("Could not create G1YoungRemSetSamplingThread");
+    vm_shutdown_during_initialization("Could not create G1ServiceThread");
     return JNI_ENOMEM;
   }
   return JNI_OK;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -80,7 +80,7 @@ class G1CollectionSet;
 class G1Policy;
 class G1HotCardCache;
 class G1RemSet;
-class G1YoungRemSetSamplingThread;
+class G1ServiceThread;
 class G1ConcurrentMark;
 class G1ConcurrentMarkThread;
 class G1ConcurrentRefine;
@@ -154,7 +154,7 @@ class G1CollectedHeap : public CollectedHeap {
   friend class G1CheckRegionAttrTableClosure;
 
 private:
-  G1YoungRemSetSamplingThread* _young_gen_sampling_thread;
+  G1ServiceThread* _young_gen_sampling_thread;
 
   WorkGang* _workers;
   G1CardTable* _card_table;
@@ -545,7 +545,7 @@ private:
   void verify_numa_regions(const char* desc);
 
 public:
-  G1YoungRemSetSamplingThread* sampling_thread() const { return _young_gen_sampling_thread; }
+  G1ServiceThread* sampling_thread() const { return _young_gen_sampling_thread; }
 
   WorkGang* workers() const { return _workers; }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -154,7 +154,7 @@ class G1CollectedHeap : public CollectedHeap {
   friend class G1CheckRegionAttrTableClosure;
 
 private:
-  G1ServiceThread* _young_gen_sampling_thread;
+  G1ServiceThread* _service_thread;
 
   WorkGang* _workers;
   G1CardTable* _card_table;
@@ -545,7 +545,7 @@ private:
   void verify_numa_regions(const char* desc);
 
 public:
-  G1ServiceThread* sampling_thread() const { return _young_gen_sampling_thread; }
+  G1ServiceThread* service_thread() const { return _service_thread; }
 
   WorkGang* workers() const { return _workers; }
 
@@ -963,7 +963,7 @@ public:
 
 private:
   jint initialize_concurrent_refinement();
-  jint initialize_young_gen_sampling_thread();
+  jint initialize_service_thread();
 public:
   // Initialize the G1CollectedHeap to have the initial and
   // maximum sizes and remembered and barrier sets

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -53,7 +53,7 @@ void G1RemSetSummary::update() {
   g1h->concurrent_refine()->threads_do(&collector);
   _num_coarsenings = HeapRegionRemSet::n_coarsenings();
 
-  set_sampling_thread_vtime(g1h->sampling_thread()->vtime_accum());
+  set_service_thread_vtime(g1h->service_thread()->vtime_accum());
 }
 
 void G1RemSetSummary::set_rs_thread_vtime(uint thread, double value) {
@@ -72,7 +72,7 @@ G1RemSetSummary::G1RemSetSummary(bool should_update) :
   _num_coarsenings(0),
   _num_vtimes(G1ConcurrentRefine::max_num_threads()),
   _rs_threads_vtimes(NEW_C_HEAP_ARRAY(double, _num_vtimes, mtGC)),
-  _sampling_thread_vtime(0.0f) {
+  _service_thread_vtime(0.0f) {
 
   memset(_rs_threads_vtimes, 0, sizeof(double) * _num_vtimes);
 
@@ -93,7 +93,7 @@ void G1RemSetSummary::set(G1RemSetSummary* other) {
 
   memcpy(_rs_threads_vtimes, other->_rs_threads_vtimes, sizeof(double) * _num_vtimes);
 
-  set_sampling_thread_vtime(other->sampling_thread_vtime());
+  set_service_thread_vtime(other->service_thread_vtime());
 }
 
 void G1RemSetSummary::subtract_from(G1RemSetSummary* other) {
@@ -106,7 +106,7 @@ void G1RemSetSummary::subtract_from(G1RemSetSummary* other) {
     set_rs_thread_vtime(i, other->rs_thread_vtime(i) - rs_thread_vtime(i));
   }
 
-  _sampling_thread_vtime = other->sampling_thread_vtime() - _sampling_thread_vtime;
+  _service_thread_vtime = other->service_thread_vtime() - _service_thread_vtime;
 }
 
 class RegionTypeCounter {
@@ -328,7 +328,7 @@ void G1RemSetSummary::print_on(outputStream* out) {
   }
   out->cr();
   out->print_cr("  Concurrent sampling threads times (s)");
-  out->print_cr("         %5.2f", sampling_thread_vtime());
+  out->print_cr("         %5.2f", service_thread_vtime());
 
   HRRSStatsIter blk;
   G1CollectedHeap::heap()->heap_region_iterate(&blk);

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -30,7 +30,7 @@
 #include "gc/g1/g1DirtyCardQueue.hpp"
 #include "gc/g1/g1RemSet.hpp"
 #include "gc/g1/g1RemSetSummary.hpp"
-#include "gc/g1/g1YoungRemSetSamplingThread.hpp"
+#include "gc/g1/g1ServiceThread.hpp"
 #include "gc/g1/heapRegion.hpp"
 #include "gc/g1/heapRegionRemSet.hpp"
 #include "memory/allocation.inline.hpp"

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.hpp
@@ -38,11 +38,11 @@ class G1RemSetSummary {
   size_t _num_vtimes;
   double* _rs_threads_vtimes;
 
-  double _sampling_thread_vtime;
+  double _service_thread_vtime;
 
   void set_rs_thread_vtime(uint thread, double value);
-  void set_sampling_thread_vtime(double value) {
-    _sampling_thread_vtime = value;
+  void set_service_thread_vtime(double value) {
+    _service_thread_vtime = value;
   }
 
   // update this summary with current data from various places
@@ -62,8 +62,8 @@ public:
 
   double rs_thread_vtime(uint thread) const;
 
-  double sampling_thread_vtime() const {
-    return _sampling_thread_vtime;
+  double service_thread_vtime() const {
+    return _service_thread_vtime;
   }
 
   size_t num_coarsenings() const {

--- a/src/hotspot/share/gc/g1/g1ServiceThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.cpp
@@ -28,17 +28,17 @@
 #include "gc/g1/g1ConcurrentMark.inline.hpp"
 #include "gc/g1/g1ConcurrentMarkThread.inline.hpp"
 #include "gc/g1/g1Policy.hpp"
-#include "gc/g1/g1YoungRemSetSamplingThread.hpp"
+#include "gc/g1/g1ServiceThread.hpp"
 #include "gc/g1/heapRegion.inline.hpp"
 #include "gc/g1/heapRegionRemSet.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
 #include "memory/universe.hpp"
 #include "runtime/mutexLocker.hpp"
 
-G1YoungRemSetSamplingThread::G1YoungRemSetSamplingThread() :
+G1ServiceThread::G1ServiceThread() :
     ConcurrentGCThread(),
     _monitor(Mutex::nonleaf,
-             "G1YoungRemSetSamplingThread monitor",
+             "G1ServiceThread monitor",
              true,
              Monitor::_safepoint_check_never),
     _last_periodic_gc_attempt_s(os::elapsedTime()),
@@ -47,7 +47,7 @@ G1YoungRemSetSamplingThread::G1YoungRemSetSamplingThread() :
   create_and_start();
 }
 
-void G1YoungRemSetSamplingThread::sleep_before_next_cycle() {
+void G1ServiceThread::sleep_before_next_cycle() {
   MonitorLocker ml(&_monitor, Mutex::_no_safepoint_check_flag);
   if (!should_terminate()) {
     uintx waitms = G1ConcRefinementServiceIntervalMillis;
@@ -55,7 +55,7 @@ void G1YoungRemSetSamplingThread::sleep_before_next_cycle() {
   }
 }
 
-bool G1YoungRemSetSamplingThread::should_start_periodic_gc() {
+bool G1ServiceThread::should_start_periodic_gc() {
   // If we are currently in a concurrent mark we are going to uncommit memory soon.
   if (G1CollectedHeap::heap()->concurrent_mark()->cm_thread()->during_cycle()) {
     log_debug(gc, periodic)("Concurrent cycle in progress. Skipping.");
@@ -82,7 +82,7 @@ bool G1YoungRemSetSamplingThread::should_start_periodic_gc() {
   return true;
 }
 
-void G1YoungRemSetSamplingThread::check_for_periodic_gc(){
+void G1ServiceThread::check_for_periodic_gc(){
   // If disabled, just return.
   if (G1PeriodicGCInterval == 0) {
     return;
@@ -98,7 +98,7 @@ void G1YoungRemSetSamplingThread::check_for_periodic_gc(){
   }
 }
 
-void G1YoungRemSetSamplingThread::run_service() {
+void G1ServiceThread::run_service() {
   double vtime_start = os::elapsedVTime();
 
   while (!should_terminate()) {
@@ -116,17 +116,17 @@ void G1YoungRemSetSamplingThread::run_service() {
   }
 }
 
-void G1YoungRemSetSamplingThread::stop_service() {
+void G1ServiceThread::stop_service() {
   MutexLocker x(&_monitor, Mutex::_no_safepoint_check_flag);
   _monitor.notify();
 }
 
-class G1YoungRemSetSamplingClosure : public HeapRegionClosure {
+class G1ServiceClosure : public HeapRegionClosure {
   SuspendibleThreadSetJoiner* _sts;
   size_t _regions_visited;
   size_t _sampled_rs_length;
 public:
-  G1YoungRemSetSamplingClosure(SuspendibleThreadSetJoiner* sts) :
+  G1ServiceClosure(SuspendibleThreadSetJoiner* sts) :
     HeapRegionClosure(), _sts(sts), _regions_visited(0), _sampled_rs_length(0) { }
 
   virtual bool do_heap_region(HeapRegion* r) {
@@ -153,13 +153,13 @@ public:
   size_t sampled_rs_length() const { return _sampled_rs_length; }
 };
 
-void G1YoungRemSetSamplingThread::sample_young_list_rs_length() {
+void G1ServiceThread::sample_young_list_rs_length() {
   SuspendibleThreadSetJoiner sts;
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   G1Policy* policy = g1h->policy();
 
   if (policy->use_adaptive_young_list_length()) {
-    G1YoungRemSetSamplingClosure cl(&sts);
+    G1ServiceClosure cl(&sts);
 
     G1CollectionSet* g1cs = g1h->collection_set();
     g1cs->iterate(&cl);

--- a/src/hotspot/share/gc/g1/g1ServiceThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.cpp
@@ -121,12 +121,12 @@ void G1ServiceThread::stop_service() {
   _monitor.notify();
 }
 
-class G1ServiceClosure : public HeapRegionClosure {
+class G1YoungRemSetSamplingClosure : public HeapRegionClosure {
   SuspendibleThreadSetJoiner* _sts;
   size_t _regions_visited;
   size_t _sampled_rs_length;
 public:
-  G1ServiceClosure(SuspendibleThreadSetJoiner* sts) :
+  G1YoungRemSetSamplingClosure(SuspendibleThreadSetJoiner* sts) :
     HeapRegionClosure(), _sts(sts), _regions_visited(0), _sampled_rs_length(0) { }
 
   virtual bool do_heap_region(HeapRegion* r) {
@@ -159,7 +159,7 @@ void G1ServiceThread::sample_young_list_rs_length() {
   G1Policy* policy = g1h->policy();
 
   if (policy->use_adaptive_young_list_length()) {
-    G1ServiceClosure cl(&sts);
+    G1YoungRemSetSamplingClosure cl(&sts);
 
     G1CollectionSet* g1cs = g1h->collection_set();
     g1cs->iterate(&cl);

--- a/src/hotspot/share/gc/g1/g1ServiceThread.hpp
+++ b/src/hotspot/share/gc/g1/g1ServiceThread.hpp
@@ -22,24 +22,16 @@
  *
  */
 
-#ifndef SHARE_GC_G1_G1YOUNGREMSETSAMPLINGTHREAD_HPP
-#define SHARE_GC_G1_G1YOUNGREMSETSAMPLINGTHREAD_HPP
+#ifndef SHARE_GC_G1_G1SERVICETHREAD_HPP
+#define SHARE_GC_G1_G1SERVICETHREAD_HPP
 
 #include "gc/shared/concurrentGCThread.hpp"
 
-// The G1YoungRemSetSamplingThread is used to re-assess the validity of
-// the prediction for the remembered set lengths of the young generation.
-//
-// At the end of the GC G1 determines the length of the young gen based on
-// how much time the next GC can take, and when the next GC may occur
-// according to the MMU.
-//
-// The assumption is that a significant part of the GC is spent on scanning
-// the remembered sets (and many other components), so this thread constantly
-// reevaluates the prediction for the remembered set scanning costs, and potentially
-// G1Policy resizes the young gen. This may do a premature GC or even
-// increase the young gen size to keep pause time length goal.
-class G1YoungRemSetSamplingThread: public ConcurrentGCThread {
+// The G1ServiceThread is used to do a number of different task:
+//   - re-assess the validity of the prediction for the
+//     remembered set lengths of the young generation.
+//   - check if a periodic GC should be scheduled.
+class G1ServiceThread: public ConcurrentGCThread {
 private:
   Monitor _monitor;
 
@@ -47,6 +39,17 @@ private:
 
   double _vtime_accum;  // Accumulated virtual time.
 
+  // Sample the current length of remembered sets for young.
+  //
+  // At the end of the GC G1 determines the length of the young gen based on
+  // how much time the next GC can take, and when the next GC may occur
+  // according to the MMU.
+  //
+  // The assumption is that a significant part of the GC is spent on scanning
+  // the remembered sets (and many other components), so this thread constantly
+  // reevaluates the prediction for the remembered set scanning costs, and potentially
+  // G1Policy resizes the young gen. This may do a premature GC or even
+  // increase the young gen size to keep pause time length goal.
   void sample_young_list_rs_length();
 
   void run_service();
@@ -59,8 +62,8 @@ private:
   bool should_start_periodic_gc();
 
 public:
-  G1YoungRemSetSamplingThread();
+  G1ServiceThread();
   double vtime_accum() { return _vtime_accum; }
 };
 
-#endif // SHARE_GC_G1_G1YOUNGREMSETSAMPLINGTHREAD_HPP
+#endif // SHARE_GC_G1_G1SERVICETHREAD_HPP


### PR DESCRIPTION
I'm renaming G1YoungRemsetSamplingThread to better reflect that it no longer just do rem set sampling.

Please review.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252141](https://bugs.openjdk.java.net/browse/JDK-8252141): Rename G1YoungRemSetSamplingThread to better reflect its purpose


### Download
`$ git fetch https://git.openjdk.java.net/playground pull/15/head:pull/15`
`$ git checkout pull/15`
