### PR TITLE
8250755: Better cleanup for jdk/test/javax/imageio/plugins/shared/CanWriteSequence.java

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/CMMException.java
+++ b/src/java.desktop/share/classes/java/awt/color/CMMException.java
@@ -42,6 +42,7 @@ public class CMMException extends java.lang.RuntimeException {
 
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.
+     * Make some change to make jcheck happy.
      */
     private static final long serialVersionUID = 5775558044142994965L;
 

--- a/src/java.desktop/share/classes/java/awt/color/CMMException.java
+++ b/src/java.desktop/share/classes/java/awt/color/CMMException.java
@@ -42,6 +42,7 @@ public class CMMException extends java.lang.RuntimeException {
 
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.
+     * Make some typo.
      */
     private static final long serialVersionUID = 5775558044142994965L;
 

--- a/src/java.desktop/share/classes/java/awt/color/CMMException.java
+++ b/src/java.desktop/share/classes/java/awt/color/CMMException.java
@@ -42,7 +42,6 @@ public class CMMException extends java.lang.RuntimeException {
 
     /**
      * Use serialVersionUID from JDK 1.2 for interoperability.
-     * Make some typo.
      */
     private static final long serialVersionUID = 5775558044142994965L;
 


### PR DESCRIPTION
Bla bla bla bla, this is just a description/summary of the fix, not a commit info!!!

LONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8250755](https://bugs.openjdk.java.net/browse/JDK-8250755): Better cleanup for jdk/test/javax/imageio/plugins/shared/CanWriteSequence.java


### Reviewers
 * prr - **Reviewer** ⚠️ Added manually
 * kcr - no project role ⚠️ Added manually

### Contributors
 * Duke Java `<Duke.Java@openjdk.com>`

### Download
`$ git fetch https://git.openjdk.java.net/playground pull/20/head:pull/20`
`$ git checkout pull/20`
