### PR TITLE
1234567:  This is my RedZone correction.

### DIFF
--- a/RedZone.txt
+++ b/RedZone.txt
@@ -1,0 +1,5 @@
+The white zone is for immediate loading and unloading of passengers only.
+There is no stopping in a red zone.
+
+The red zone is for immediate loading and unloading of passengers only.
+There is no stopping in a white zone.

--- a/RedZone.txt
+++ b/RedZone.txt
@@ -5,3 +5,5 @@ The red zone is for immediate loading and unloading of passengers only.
 There is no stopping in a white zone.
 
 No, the white zone is for loading. Now, there is no stopping in a RED zone.
+
+Don't you tell me which zone is for loading, and which zone is for unloading.

--- a/RedZone.txt
+++ b/RedZone.txt
@@ -3,3 +3,5 @@ There is no stopping in a red zone.
 
 The red zone is for immediate loading and unloading of passengers only.
 There is no stopping in a white zone.
+
+No, the white zone is for loading. Now, there is no stopping in a RED zone.

--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -353,7 +353,7 @@ import java.util.function.BiFunction;
  *      may execute concurrently of each other.
  *
  *      <li> The SSL/TLS/DTLS protocols employ ordered packets.
- *      Applications must take care to ensure that generated packets
+ *      Applications must ake care to ensure that generated packets
  *      are delivered in sequence.  If packets arrive
  *      out-of-order, unexpected or fatal results may occur.
  * <P>
@@ -371,11 +371,11 @@ import java.util.function.BiFunction;
  *      because there is no way to guarantee the eventual packet ordering.
  * </OL>
  *
- * @see SSLContext
  * @see SSLSocket
  * @see SSLServerSocket
  * @see SSLSession
  * @see java.net.Socket
+ * @see SSLContext
  *
  * @since 1.5
  * @author Brad R. Wetmore


### PR DESCRIPTION
Of course, the red zone (or is it the white zone?) is for the immediate loading...
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issues
 * [JDK-1234567](https://bugs.openjdk.java.net/browse/JDK-1234567): Date objects do not preserve milliseconds properly ⚠️ Title mismatch between PR and JBS.
 * [JDK-8250968](https://bugs.openjdk.java.net/browse/JDK-8250968): Symlinks attributes not preserved when using jarsigner on zip files
 * [JDK-8193209](https://bugs.openjdk.java.net/browse/JDK-8193209): JEP 356: Enhanced Pseudo-Random Number Generators


### Contributors
 * Xue-Lei Andrew Fan `<xuelei@openjdk.org>`
 * Weijun Wang `<weijun@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/playground pull/55/head:pull/55`
`$ git checkout pull/55`
