### PR TITLE
JDK-123456: missing comma in XMLEventFactory.java

### DIFF
--- a/src/java.xml/share/classes/javax/xml/stream/XMLEventFactory.java
+++ b/src/java.xml/share/classes/javax/xml/stream/XMLEventFactory.java
@@ -129,7 +129,7 @@ public abstract class XMLEventFactory {
    * </li>
    * </ul>
    * <p>
-   *   Once an application has obtained a reference to a XMLEventFactory it
+   *   Once an application has obtained a reference to a XMLEventFactory, it
    *   can use the factory to configure and obtain stream instances.
    *
    * @return an instance of the {@code XMLEventFactory}


### PR DESCRIPTION
Adds a missing comma in XMLEventFactory.java

/issue JDK-12345678
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * ⚠️ Failed to retrieve information on issue `JDK-123456`.


### Download
`$ git fetch https://git.openjdk.java.net/playground pull/66/head:pull/66`
`$ git checkout pull/66`
