### PR TITLE
8256299: Implement JEP 396: Strongly Encapsulate JDK Internals by Default

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2560,6 +2560,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
         return res;
       }
     } else if (match_option(option, "--illegal-access=", &tail)) {
+      warning("Option --illegal-access is deprecated and will be removed in a future release.");
       if (!create_module_property("jdk.module.illegalAccess", tail, ExternalProperty)) {
         return JNI_ENOMEM;
       }

--- a/src/java.base/share/classes/jdk/internal/module/ArchivedBootLayer.java
+++ b/src/java.base/share/classes/jdk/internal/module/ArchivedBootLayer.java
@@ -27,35 +27,27 @@ package jdk.internal.module;
 import jdk.internal.misc.CDS;
 
 /**
- * Used by ModuleBootstrap for archiving the boot layer and the builder needed to
- * set the IllegalAccessLogger.
+ * Used by ModuleBootstrap for archiving the boot layer.
  */
 class ArchivedBootLayer {
     private static ArchivedBootLayer archivedBootLayer;
 
     private final ModuleLayer bootLayer;
-    private final IllegalAccessLogger.Builder builder;
 
-    private ArchivedBootLayer(ModuleLayer bootLayer,
-                              IllegalAccessLogger.Builder builder) {
+    private ArchivedBootLayer(ModuleLayer bootLayer) {
         this.bootLayer = bootLayer;
-        this.builder = builder;
     }
 
     ModuleLayer bootLayer() {
         return bootLayer;
     }
 
-    IllegalAccessLogger.Builder illegalAccessLoggerBuilder() {
-        return builder;
-    }
-
     static ArchivedBootLayer get() {
         return archivedBootLayer;
     }
 
-    static void archive(ModuleLayer layer, IllegalAccessLogger.Builder builder) {
-        archivedBootLayer = new ArchivedBootLayer(layer, builder);
+    static void archive(ModuleLayer layer) {
+        archivedBootLayer = new ArchivedBootLayer(layer);
     }
 
     static {

--- a/src/java.base/share/classes/jdk/internal/module/ArchivedModuleGraph.java
+++ b/src/java.base/share/classes/jdk/internal/module/ArchivedModuleGraph.java
@@ -24,8 +24,6 @@
  */
 package jdk.internal.module;
 
-import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.lang.module.Configuration;
 import java.lang.module.ModuleFinder;
@@ -33,7 +31,7 @@ import jdk.internal.misc.CDS;
 
 /**
  * Used by ModuleBootstrap for archiving the configuration for the boot layer,
- * the system module finder, and the maps used to create the IllegalAccessLogger.
+ * and the system module finder.
  */
 class ArchivedModuleGraph {
     private static ArchivedModuleGraph archivedModuleGraph;
@@ -43,23 +41,17 @@ class ArchivedModuleGraph {
     private final ModuleFinder finder;
     private final Configuration configuration;
     private final Function<String, ClassLoader> classLoaderFunction;
-    private final Map<String, Set<String>> concealedPackagesToOpen;
-    private final Map<String, Set<String>> exportedPackagesToOpen;
 
     private ArchivedModuleGraph(boolean hasSplitPackages,
                                 boolean hasIncubatorModules,
                                 ModuleFinder finder,
                                 Configuration configuration,
-                                Function<String, ClassLoader> classLoaderFunction,
-                                Map<String, Set<String>> concealedPackagesToOpen,
-                                Map<String, Set<String>> exportedPackagesToOpen) {
+                                Function<String, ClassLoader> classLoaderFunction) {
         this.hasSplitPackages = hasSplitPackages;
         this.hasIncubatorModules = hasIncubatorModules;
         this.finder = finder;
         this.configuration = configuration;
         this.classLoaderFunction = classLoaderFunction;
-        this.concealedPackagesToOpen = concealedPackagesToOpen;
-        this.exportedPackagesToOpen = exportedPackagesToOpen;
     }
 
     ModuleFinder finder() {
@@ -72,14 +64,6 @@ class ArchivedModuleGraph {
 
     Function<String, ClassLoader> classLoaderFunction() {
         return classLoaderFunction;
-    }
-
-    Map<String, Set<String>> concealedPackagesToOpen() {
-        return concealedPackagesToOpen;
-    }
-
-    Map<String, Set<String>> exportedPackagesToOpen() {
-        return exportedPackagesToOpen;
     }
 
     boolean hasSplitPackages() {
@@ -110,16 +94,12 @@ class ArchivedModuleGraph {
                         boolean hasIncubatorModules,
                         ModuleFinder finder,
                         Configuration configuration,
-                        Function<String, ClassLoader> classLoaderFunction,
-                        Map<String, Set<String>> concealedPackagesToOpen,
-                        Map<String, Set<String>> exportedPackagesToOpen) {
+                        Function<String, ClassLoader> classLoaderFunction) {
         archivedModuleGraph = new ArchivedModuleGraph(hasSplitPackages,
                                                       hasIncubatorModules,
                                                       finder,
                                                       configuration,
-                                                      classLoaderFunction,
-                                                      concealedPackagesToOpen,
-                                                      exportedPackagesToOpen);
+                                                      classLoaderFunction);
     }
 
     static {

--- a/test/jdk/tools/launcher/modules/illegalaccess/IllegalAccessTest.java
+++ b/test/jdk/tools/launcher/modules/illegalaccess/IllegalAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,13 +239,13 @@ public class IllegalAccessTest {
     }
 
     @Test(dataProvider = "denyCases")
-    public void testDeny(String action, Result expectedResult) throws Exception {
-        run(action, expectedResult, "--illegal-access=deny");
-    }
-
-    @Test(dataProvider = "permitCases")
     public void testDefault(String action, Result expectedResult) throws Exception {
         run(action, expectedResult);
+    }
+
+    @Test(dataProvider = "denyCases")
+    public void testDeny(String action, Result expectedResult) throws Exception {
+        run(action, expectedResult, "--illegal-access=deny");
     }
 
     @Test(dataProvider = "permitCases")
@@ -267,41 +267,42 @@ public class IllegalAccessTest {
         run(action, expectedResult, "--illegal-access=debug");
     }
 
-
     /**
      * Specify --add-exports to export a package
      */
     public void testWithAddExportsOption() throws Exception {
-        // warning
-        run("reflectPublicMemberNonExportedPackage", successWithWarning());
+        // not accessible
+        run("reflectPublicMemberNonExportedPackage", fail("IllegalAccessException"));
 
-        // no warning due to --add-exports
+        // should succeed with --add-exports
         run("reflectPublicMemberNonExportedPackage", successNoWarning(),
                 "--add-exports", "java.base/sun.security.x509=ALL-UNNAMED");
 
-        // attempt two illegal accesses, one allowed by --add-exports
-        run("reflectPublicMemberNonExportedPackage"
-                + ",setAccessibleNonPublicMemberExportedPackage",
-            successWithWarning(),
-            "--add-exports", "java.base/sun.security.x509=ALL-UNNAMED");
+        // not accessible
+        run("setAccessibleNonPublicMemberNonExportedPackage", fail("InaccessibleObjectException"));
+
+        // should fail as --add-exports does not open package
+        run("setAccessibleNonPublicMemberNonExportedPackage", fail("InaccessibleObjectException"),
+                "--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED");
     }
 
     /**
      * Specify --add-open to open a package
      */
     public void testWithAddOpensOption() throws Exception {
-        // warning
-        run("setAccessibleNonPublicMemberExportedPackage", successWithWarning());
+        // not accessible
+        run("reflectPublicMemberNonExportedPackage", fail("IllegalAccessException"));
 
-        // no warning due to --add-opens
+        // should succeed with --add-opens
+        run("reflectPublicMemberNonExportedPackage", successNoWarning(),
+                "--add-opens", "java.base/sun.security.x509=ALL-UNNAMED");
+
+        // not accessible
+        run("setAccessibleNonPublicMemberExportedPackage", fail("InaccessibleObjectException"));
+
+        // should succeed with --add-opens
         run("setAccessibleNonPublicMemberExportedPackage", successNoWarning(),
                 "--add-opens", "java.base/java.lang=ALL-UNNAMED");
-
-        // attempt two illegal accesses, one allowed by --add-opens
-        run("reflectPublicMemberNonExportedPackage"
-                + ",setAccessibleNonPublicMemberExportedPackage",
-            successWithWarning(),
-            "--add-opens", "java.base/java.lang=ALL-UNNAMED");
     }
 
     /**
@@ -380,12 +381,8 @@ public class IllegalAccessTest {
 
         run(jarfile, "reflectPublicMemberNonExportedPackage", successNoWarning());
 
-        run(jarfile, "setAccessibleNonPublicMemberExportedPackage", successWithWarning());
-
-        // attempt two illegal accesses, one allowed by Add-Exports
-        run(jarfile, "reflectPublicMemberNonExportedPackage,"
-                + "setAccessibleNonPublicMemberExportedPackage",
-            successWithWarning());
+        run(jarfile, "reflectPublicMemberNonExportedPackage", successNoWarning(),
+                "--illegal-access=permit");
     }
 
     /**
@@ -403,29 +400,26 @@ public class IllegalAccessTest {
 
         run(jarfile, "setAccessibleNonPublicMemberExportedPackage", successNoWarning());
 
-        run(jarfile, "reflectPublicMemberNonExportedPackage", successWithWarning());
-
-        // attempt two illegal accesses, one allowed by Add-Opens
-        run(jarfile, "reflectPublicMemberNonExportedPackage,"
-                + "setAccessibleNonPublicMemberExportedPackage",
-            successWithWarning());
+        run(jarfile, "setAccessibleNonPublicMemberExportedPackage", successNoWarning(),
+                "--illegal-access=permit");
     }
 
     /**
-     * Test that default behavior is to print a warning on the first illegal
-     * access only.
+     * Test that --illegal-access=permit behavior is to print a warning on the
+     * first illegal access only.
      */
     public void testWarnOnFirstIllegalAccess() throws Exception {
         String action1 = "reflectPublicMemberNonExportedPackage";
         String action2 = "setAccessibleNonPublicMemberExportedPackage";
-        int warningCount = count(run(action1).asLines(), "WARNING");
+        int warningCount = count(run(action1, "--illegal-access=permit").asLines(), "WARNING");
+        assertTrue(warningCount > 0);  // multi line warning
 
         // same illegal access
-        List<String> output1 = run(action1 + "," + action1).asLines();
+        List<String> output1 = run(action1 + "," + action1, "--illegal-access=permit").asLines();
         assertTrue(count(output1, "WARNING") == warningCount);
 
         // different illegal access
-        List<String> output2 = run(action1 + "," + action2).asLines();
+        List<String> output2 = run(action1 + "," + action2, "--illegal-access=permit").asLines();
         assertTrue(count(output2, "WARNING") == warningCount);
     }
 

--- a/test/jdk/tools/launcher/modules/illegalaccess/IllegalAccessTest.java
+++ b/test/jdk/tools/launcher/modules/illegalaccess/IllegalAccessTest.java
@@ -383,6 +383,11 @@ public class IllegalAccessTest {
 
         run(jarfile, "reflectPublicMemberNonExportedPackage", successNoWarning(),
                 "--illegal-access=permit");
+
+        // should fail as --add-exports does not open package
+        run(jarfile, "setAccessibleNonPublicMemberNonExportedPackage",
+            fail("InaccessibleObjectException"),
+            "--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED");
     }
 
     /**

--- a/test/jdk/tools/launcher/modules/illegalaccess/IllegalAccessTest.java
+++ b/test/jdk/tools/launcher/modules/illegalaccess/IllegalAccessTest.java
@@ -374,7 +374,8 @@ public class IllegalAccessTest {
         Attributes attrs = man.getMainAttributes();
         attrs.put(Attributes.Name.MANIFEST_VERSION, "1.0");
         attrs.put(Attributes.Name.MAIN_CLASS, "TryAccess");
-        attrs.put(new Attributes.Name("Add-Exports"), "java.base/sun.security.x509");
+        attrs.put(new Attributes.Name("Add-Exports"),
+                  "java.base/sun.security.x509 java.base/java.lang");
         Path jarfile = Paths.get("x.jar");
         Path classes = Paths.get(TEST_CLASSES);
         JarUtils.createJarFile(jarfile, man, classes, Paths.get("TryAccess.class"));

--- a/test/jdk/tools/launcher/modules/illegalaccess/IllegalAccessTest.java
+++ b/test/jdk/tools/launcher/modules/illegalaccess/IllegalAccessTest.java
@@ -374,7 +374,8 @@ public class IllegalAccessTest {
         Attributes attrs = man.getMainAttributes();
         attrs.put(Attributes.Name.MANIFEST_VERSION, "1.0");
         attrs.put(Attributes.Name.MAIN_CLASS, "TryAccess");
-        attrs.put(new Attributes.Name("Add-Exports"), "java.base/sun.security.x509");
+        attrs.put(new Attributes.Name("Add-Exports"),
+                  "java.base/sun.security.x509 java.base/sun.nio.ch");
         Path jarfile = Paths.get("x.jar");
         Path classes = Paths.get(TEST_CLASSES);
         JarUtils.createJarFile(jarfile, man, classes, Paths.get("TryAccess.class"));
@@ -384,10 +385,9 @@ public class IllegalAccessTest {
         run(jarfile, "reflectPublicMemberNonExportedPackage", successNoWarning(),
                 "--illegal-access=permit");
 
-        // should fail as --add-exports does not open package
+        // should fail as Add-Exports does not open package
         run(jarfile, "setAccessibleNonPublicMemberNonExportedPackage",
-            fail("InaccessibleObjectException"),
-            "--add-exports", "java.base/sun.nio.ch=ALL-UNNAMED");
+            fail("InaccessibleObjectException"));
     }
 
     /**

--- a/test/jdk/tools/launcher/modules/illegalaccess/IllegalAccessTest.java
+++ b/test/jdk/tools/launcher/modules/illegalaccess/IllegalAccessTest.java
@@ -374,8 +374,7 @@ public class IllegalAccessTest {
         Attributes attrs = man.getMainAttributes();
         attrs.put(Attributes.Name.MANIFEST_VERSION, "1.0");
         attrs.put(Attributes.Name.MAIN_CLASS, "TryAccess");
-        attrs.put(new Attributes.Name("Add-Exports"),
-                  "java.base/sun.security.x509 java.base/java.lang");
+        attrs.put(new Attributes.Name("Add-Exports"), "java.base/sun.security.x509");
         Path jarfile = Paths.get("x.jar");
         Path classes = Paths.get(TEST_CLASSES);
         JarUtils.createJarFile(jarfile, man, classes, Paths.get("TryAccess.class"));

--- a/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
+++ b/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
@@ -39,7 +39,7 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @summary ASN.1 formatting
- * @modules java.base/sun.security.util
+ * @modules java.base/sun.security.util:open
  * @library /test/lib
  * @compile ASN1FormatterTest.java
  * @run testng jdk.test.lib.hexdump.ASN1FormatterTest

--- a/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
+++ b/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
@@ -39,7 +39,7 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @summary ASN.1 formatting
- * @modules java.base/sun.security.util:open
+ * @modules java.base/sun.security.util
  * @library /test/lib
  * @compile ASN1FormatterTest.java
  * @run testng jdk.test.lib.hexdump.ASN1FormatterTest


### PR DESCRIPTION
This is a test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8256299](https://bugs.openjdk.java.net/browse/JDK-8256299): Implement JEP 396: Strongly Encapsulate JDK Internals by Default


### Download
`$ git fetch https://git.openjdk.java.net/playground pull/78/head:pull/78`
`$ git checkout pull/78`
