### PR TITLE
8278104: C1 should support the compiler directive 'BreakAtExecute'

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -27,7 +27,7 @@ repository=playground
 jbs=JDK
 
 [checks]
-error=author,whitespace,executable
+error=author,whitespace,executable,reviewers
 
 [census]
 version=0

--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ or either of these files:
 
 See <https://openjdk.java.net/> for more information about
 the wonderful OpenJDK Community and the amazing JDK.
+    
 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ or either of these files:
 
 See <https://openjdk.java.net/> for more information about
 the wonderful OpenJDK Community and the amazing JDK.
+

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Arguments.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Arguments.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
+        
 package com.sun.tools.javac.main;
 
 import java.io.IOException;


### PR DESCRIPTION
test
### Issue\r * [JDK-8278104](https://bugs.openjdk.java.net/browse/JDK-8278104): C1 should support the compiler directive 'BreakAtExecute'

### Issue\r\n * [JDK-8278104](https://bugs.openjdk.java.net/browse/JDK-8278104): C1 should support the compiler directive 'BreakAtExecute'

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Change requires a JEP request to be targeted

### Issues
 * [JDK-8278104](https://bugs.openjdk.java.net/browse/JDK-8278104): C1 should support the compiler directive 'BreakAtExecute' ⚠️ Issue is not open.
 * [JDK-8046114](https://bugs.openjdk.java.net/browse/JDK-8046114): JEP 124: Enhance the Certificate Revocation-Checking API (**JEP**) ⚠️ Issue is not open.


### Contributors
 * Zhang `<Zhang@gmail.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/playground pull/94/head:pull/94` \
`$ git checkout pull/94`

Update a local copy of the PR: \
`$ git checkout pull/94` \
`$ git pull https://git.openjdk.java.net/playground pull/94/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 94`

View PR using the GUI difftool: \
`$ git pr show -t 94`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/playground/pull/94.diff">https://git.openjdk.java.net/playground/pull/94.diff</a>

</details>
