### PR TITLE
8291750: test

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -885,5 +885,6 @@ java/awt/print/PrinterJob/ScaledText/ScaledText.java 8231226 macosx-all
 java/awt/font/TextLayout/TestJustification.html 8250791 macosx-all
 javax/swing/JTabbedPane/4209065/bug4209065.java 8251177 macosx-all
 java/awt/TrayIcon/DragEventSource/DragEventSource.java 8252242 macosx-all
+java/awt/TrayIcon/DragEventSource/DragEventSource.java 8291750 macosx-all
 
 ############################################################################


### PR DESCRIPTION
A large amount of manual adjustments were needed because the original fix was based on a much newer codebase. The major changes are in

* archiveUtils.cpp
* filemap.cpp
* metaspace.cpp
* metaspaceShared.cpp
* virtualMemoryTracker.cpp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8291750](https://bugs-stage.openjdk.org/browse/JDK-8291750): test ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/playground pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.org/playground pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/playground/pull/105.diff">https://git.openjdk.org/playground/pull/105.diff</a>

</details>
