### PR TITLE
8328101: Parallel: Obsolete ParallelOldDeadWoodLimiterMean and ParallelOldDeadWoodLimiterStdDev

### DIFF
--- a/test.java
+++ b/test.java
@@ -1,3 +1,4 @@
 aaaaa
 backport
 0831
+0325


### PR DESCRIPTION
TestBackportCSR

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issues
 * [JDK-8328101](https://bugs-stage.openjdk.org/browse/JDK-8328101): Parallel: Obsolete ParallelOldDeadWoodLimiterMean and ParallelOldDeadWoodLimiterStdDev (**Enhancement** - P4)
 * [JDK-8328272](https://bugs-stage.openjdk.org/browse/JDK-8328272): [AIX] Use flag kind "diagnostic" for platform specific flags (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/playground.git pull/187/head:pull/187` \
`$ git checkout pull/187`

Update a local copy of the PR: \
`$ git checkout pull/187` \
`$ git pull https://git.openjdk.org/playground.git pull/187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 187`

View PR using the GUI difftool: \
`$ git pr show -t 187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/playground/pull/187.diff">https://git.openjdk.org/playground/pull/187.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/playground/pull/187#issuecomment-2020840931)