### PR TITLE
8336355: Fourth issue for testing SKARA-2312

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2821,6 +2821,8 @@ public final class String
      *
      * @return  the stream of lines extracted from this string
      *
+     * A new development in mainline.
+     *
      * @since 11
      */
     public Stream<String> lines() {


### PR DESCRIPTION
New development in the mainline (to test SKARA-2312).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8336355](https://bugs-stage.openjdk.org/browse/JDK-8336355): Fourth issue for testing SKARA-2312 (**Bug** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**) ⚠️ Review applies to [79927c01](https://git.openjdk.org/playground/pull/220/files/79927c01394a690713b43f2614a63e2b9e7297b6)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/playground.git pull/220/head:pull/220` \
`$ git checkout pull/220`

Update a local copy of the PR: \
`$ git checkout pull/220` \
`$ git pull https://git.openjdk.org/playground.git pull/220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 220`

View PR using the GUI difftool: \
`$ git pr show -t 220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/playground/pull/220.diff">https://git.openjdk.org/playground/pull/220.diff</a>

</details>
